### PR TITLE
Update bedrock_model_factory call with keyword args

### DIFF
--- a/src/strands_env/cli/utils.py
+++ b/src/strands_env/cli/utils.py
@@ -84,7 +84,7 @@ def build_model_factory(config: ModelConfig, max_concurrency: int) -> ModelFacto
             session = get_assumed_role_session(config.role_arn, config.region)
         else:
             session = get_boto3_session(config.region, config.profile_name)
-        return bedrock_model_factory(session, config.model_id, sampling)
+        return bedrock_model_factory(boto_session=session, model_id=config.model_id, sampling_params=sampling)
 
     else:
         raise click.ClickException(f"Unknown backend: {config.backend}")


### PR DESCRIPTION
The bedrock_model_factory function in src/strands_env/core/models.py:107 is defined with keyword-only arguments (the *, syntax on line 108 forces all parameters to be keyword-only):

```
 def bedrock_model_factory(
   *,
   model_id: str,
   boto_session: boto3.Session,
   boto_client_config: botocore.config.Config = DEFAULT_BOTO_CLIENT_CONFIG,
   sampling_params: dict[str, Any] = DEFAULT_SAMPLING_PARAMS,
 ) -> ModelFactory:
```

However, in src/strands_env/cli/utils.py:87, the function was being called with positional arguments:

`return bedrock_model_factory(session, config.model_id, sampling)`

This causes the following error:

`TypeError: bedrock_model_factory() takes 0 positional arguments but 3 were given`

**Fix**: Updated the function call to use keyword arguments:

`return bedrock_model_factory(boto_session=session, model_id=config.model_id, sampling_params=sampling)`