### PR TITLE
feat(core): add routing replay support for MoE models

### DIFF
--- a/src/strands_env/cli/config.py
+++ b/src/strands_env/cli/config.py
@@ -62,6 +62,9 @@ class ModelConfig:
     # Sampling
     sampling: SamplingConfig = field(default_factory=SamplingConfig)
 
+    # SGLang TITO options
+    return_routed_experts: bool = False  # Record MoE routing decisions for routing replay
+
     def to_dict(self) -> dict:
         """Convert to dict for serialization."""
         return {
@@ -74,6 +77,7 @@ class ModelConfig:
             "profile_name": self.profile_name,
             "role_arn": self.role_arn,
             "sampling": self.sampling.to_dict(),
+            "return_routed_experts": self.return_routed_experts,
         }
 
 

--- a/src/strands_env/cli/utils.py
+++ b/src/strands_env/cli/utils.py
@@ -268,6 +268,7 @@ def _build_sglang_model_factory(config: ModelConfig, max_concurrency: int, sampl
         tokenizer=tokenizer,
         tool_parser=tool_parser,
         sampling_params=sampling,
+        return_routed_experts=config.return_routed_experts,
     )
 
 

--- a/src/strands_env/core/models.py
+++ b/src/strands_env/core/models.py
@@ -70,6 +70,7 @@ def sglang_model_factory(
     sampling_params: dict[str, Any] = DEFAULT_SAMPLING_PARAMS,
     return_logprob: bool = True,
     enable_thinking: bool | None = None,
+    return_routed_experts: bool = False,
 ) -> ModelFactory:
     """Return a factory that creates `SGLangModel` instances.
 
@@ -80,6 +81,7 @@ def sglang_model_factory(
         sampling_params: Sampling parameters for the model (e.g. `{"max_new_tokens": 4096}`).
         return_logprob: Whether to return logprobs for each token.
         enable_thinking: Enable thinking mode for Qwen3 hybrid models.
+        return_routed_experts: Record MoE routing decisions for routing replay.
     """
     if tool_parser is None:
         tool_parser = HermesToolParser()
@@ -91,6 +93,7 @@ def sglang_model_factory(
         sampling_params=sampling_params,
         return_logprob=return_logprob,
         enable_thinking=enable_thinking,
+        return_routed_experts=return_routed_experts,
     )
 
 

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -64,12 +64,14 @@ class TokenObservation(BaseModel):
 
     `prompt_length` splits the flat `token_ids` list into initial-prompt vs. rollout.
     `loss_mask` and `logprobs` cover all tokens (use rollout slices for training).
+    `routed_experts` holds base64-encoded MoE routing decisions for routing replay.
     """
 
     token_ids: list[int] = Field(default_factory=list)
     prompt_length: int = Field(default=0)
     loss_mask: list[int] = Field(default_factory=list)
     logprobs: list[float | None] = Field(default_factory=list)
+    routed_experts: str | None = Field(default=None)
 
     @property
     def rollout_token_ids(self) -> list[int]:
@@ -97,6 +99,7 @@ class TokenObservation(BaseModel):
             prompt_length=len(token_manager.initial_prompt),
             loss_mask=token_manager.loss_mask,
             logprobs=token_manager.logprobs,
+            routed_experts=token_manager.routed_experts,
         )
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -47,6 +47,24 @@ class TestSGLangModelFactory:
         model2 = factory()
         assert model1 is not model2
 
+    def test_return_routed_experts_passed_through(self):
+        factory = sglang_model_factory(
+            tokenizer=MagicMock(),
+            client=MagicMock(spec=SGLangClient),
+            return_routed_experts=True,
+        )
+        model = factory()
+        assert isinstance(model, SGLangModel)
+        assert model.get_config()["return_routed_experts"] is True
+
+    def test_return_routed_experts_default_false(self):
+        factory = sglang_model_factory(
+            tokenizer=MagicMock(),
+            client=MagicMock(spec=SGLangClient),
+        )
+        model = factory()
+        assert model.get_config().get("return_routed_experts", False) is False
+
 
 # ---------------------------------------------------------------------------
 # bedrock_model_factory


### PR DESCRIPTION
## Summary
- Propagate `routed_experts` from `TokenManager` through `TokenObservation` and `sglang_model_factory`
- Wire `return_routed_experts` option through CLI config

**Note:** Requires unreleased `strands-sglang` with routing replay support.