### PR TITLE
Fix TypeError: Object of type PosixPath is not JSON serializable in src/strands-env/cli/eval.py

### DIFF
--- a/src/strands_env/cli/eval.py
+++ b/src/strands_env/cli/eval.py
@@ -357,7 +357,7 @@ def run_cmd(
         "eval": eval_config.to_dict(),
     }
     with open(config_path, "w", encoding="utf-8") as f:
-        json.dump(config_data, f, indent=2)
+        json.dump(config_data, f, indent=2, default=str)
     click.echo(f"Saved config to {config_path}")
 
     # Run evaluation


### PR DESCRIPTION
## Issue

  Running `strands-env eval run` with `--output` crashes when saving `config.json`:

  File "src/strands_env/cli/eval.py", line 360, in run_cmd
      json.dump(config_data, f, indent=2)
  TypeError: Object of type PosixPath is not JSON serializable

Omitting `--output` works since `None` is JSON-serializable.

  ## Root Cause

  The `--output` CLI option uses `click.Path(path_type=Path)` which converts the argument to a `pathlib.Path`. This `Path` object flows through  `EvalConfig.to_dict()` (which uses `dataclasses.asdict()`) into `config_data`, and `json.dump` cannot serialize it.

  ## Fix

  Add `default=str` to the `json.dump` calls in `eval.py`:

  ```python
  json.dump(config_data, f, indent=2, default=str)
```
  This tells the JSON encoder to call `str()` on any non-serializable object (e.g. Path). This also future-proofs against other non-serializable types that may be added to the config data. 