### PR TITLE
refactor(aws): cache boto3 client instead of session for thread safety

### DIFF
--- a/src/strands_env/environments/code_sandbox/README.md
+++ b/src/strands_env/environments/code_sandbox/README.md
@@ -16,12 +16,12 @@ A sandboxed code execution environment using AWS Bedrock AgentCore Code Interpre
 
 ```python
 from strands_env.environments.code_sandbox import CodeSandboxEnv, CodeMode
-from strands_env.utils.aws import get_session
+from strands_env.utils.aws import get_client
 
-session = get_session(region="us-east-1")
+client = get_client("bedrock-agentcore", region="us-east-1")
 env = CodeSandboxEnv(
     model_factory=model_factory,
-    boto3_session=session,
+    client=client,
     mode=CodeMode.CODE,  # CODE, TERMINAL, or CODE_AND_TERMINAL
 )
 

--- a/src/strands_env/environments/code_sandbox/env.py
+++ b/src/strands_env/environments/code_sandbox/env.py
@@ -24,10 +24,10 @@ from typing_extensions import override
 
 from strands_env.core.environment import Environment
 from strands_env.tools import CodeInterpreterToolkit
-from strands_env.utils.aws import get_session
+from strands_env.utils.aws import get_client
 
 if TYPE_CHECKING:
-    import boto3
+    from botocore.client import BaseClient
 
     from strands_env.core.types import ModelFactory, RewardFunction
 
@@ -53,11 +53,11 @@ class CodeSandboxEnv(Environment):
 
     Example:
         from strands_env.environments.code_sandbox import CodeSandboxEnv, CodeMode
-        from strands_env.utils.aws import get_session
+        from strands_env.utils.aws import get_client
 
-        session = get_session(region="us-east-1")
+        client = get_client("bedrock-agentcore", region="us-east-1")
         env = CodeSandboxEnv(
-            boto3_session=session,
+            client=client,
             model_factory=model_factory,
             mode=CodeMode.CODE,  # Only Python execution
         )
@@ -77,7 +77,7 @@ class CodeSandboxEnv(Environment):
         max_tool_iters: int | None = 10,
         max_tool_calls: int | None = 50,
         verbose: bool = False,
-        boto3_session: boto3.Session | None = None,
+        client: BaseClient | None = None,
         mode: CodeMode = CodeMode.CODE,
     ):
         super().__init__(
@@ -90,7 +90,7 @@ class CodeSandboxEnv(Environment):
         )
         self.mode = mode
         self._toolkit = CodeInterpreterToolkit(
-            boto3_session=boto3_session or get_session(), session_name="strands-env-code-sandbox"
+            client=client or get_client("bedrock-agentcore"), session_name="strands-env-code-sandbox"
         )
 
     @override

--- a/src/strands_env/tools/code_interpreter.py
+++ b/src/strands_env/tools/code_interpreter.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from strands import tool
 
 if TYPE_CHECKING:
-    import boto3
+    from botocore.client import BaseClient
 
 CODE_INTERPRETER_ID = "aws.codeinterpreter.v1"
 
@@ -34,15 +34,15 @@ class CodeInterpreterToolkit:
     and shell commands in a sandboxed environment.
 
     Example:
-        from strands_env.utils.aws import get_session
+        from strands_env.utils.aws import get_client
 
-        session = get_session(region="us-east-1")
-        toolkit = CodeInterpreterToolkit(boto3_session=session)
+        client = get_client("bedrock-agentcore", region="us-east-1")
+        toolkit = CodeInterpreterToolkit(client=client)
 
         # In environment:
         class MyEnv(Environment):
-            def __init__(self, boto3_session, ...):
-                self.toolkit = CodeInterpreterToolkit(boto3_session)
+            def __init__(self, client, ...):
+                self.toolkit = CodeInterpreterToolkit(client)
 
             def get_tools(self):
                 return [self.toolkit.execute_code, self.toolkit.execute_command]
@@ -53,18 +53,17 @@ class CodeInterpreterToolkit:
 
     def __init__(
         self,
-        boto3_session: boto3.Session,
+        client: BaseClient,
         session_name: str = "strands-env-session",
     ):
         """Initialize the toolkit.
 
         Args:
-            boto3_session: boto3 session for AWS credentials.
+            client: boto3 client for bedrock-agentcore service.
             session_name: Name for the code interpreter session.
         """
-        self.region = boto3_session.region_name
         self.session_name = session_name
-        self._client = boto3_session.client("bedrock-agentcore", region_name=self.region)
+        self._client = client
         self._session_id: str | None = None
         # Adding a session lock here to make sure each CodeInterpreterToolkit only owns one session.
         self._session_lock = asyncio.Lock()

--- a/tests/integration/test_code_sandbox.py
+++ b/tests/integration/test_code_sandbox.py
@@ -23,7 +23,7 @@ import pytest
 
 from strands_env.core.types import Action, RewardResult, StepResult, TaskContext, TerminationReason
 from strands_env.environments.code_sandbox import CodeMode, CodeSandboxEnv
-from strands_env.utils.aws import check_credentials, get_session
+from strands_env.utils.aws import check_credentials, get_client, get_session
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -31,20 +31,20 @@ from strands_env.utils.aws import check_credentials, get_session
 
 
 @pytest.fixture(scope="session")
-def boto3_session():
-    """Create a boto3 session, skipping if AWS credentials are not configured."""
+def agentcore_client():
+    """Create a bedrock-agentcore client, skipping if AWS credentials are not configured."""
     session = get_session()
     if not check_credentials(session):
         pytest.skip("AWS credentials not available")
-    return session
+    return get_client("bedrock-agentcore")
 
 
 @pytest.fixture
-async def code_env(model_factory, boto3_session):
+async def code_env(model_factory, agentcore_client):
     """CodeSandboxEnv in CODE mode with cleanup."""
     env = CodeSandboxEnv(
         model_factory=model_factory,
-        boto3_session=boto3_session,
+        client=agentcore_client,
         mode=CodeMode.CODE,
     )
     yield env
@@ -52,11 +52,11 @@ async def code_env(model_factory, boto3_session):
 
 
 @pytest.fixture
-async def terminal_env(model_factory, boto3_session):
+async def terminal_env(model_factory, agentcore_client):
     """CodeSandboxEnv in TERMINAL mode with cleanup."""
     env = CodeSandboxEnv(
         model_factory=model_factory,
-        boto3_session=boto3_session,
+        client=agentcore_client,
         mode=CodeMode.TERMINAL,
     )
     yield env
@@ -145,7 +145,7 @@ class TestCodeMode:
         result2 = await code_env.step(action2)
         assert result2.termination_reason == TerminationReason.TASK_COMPLETE
 
-    async def test_reward_fn_called(self, model_factory, boto3_session):
+    async def test_reward_fn_called(self, model_factory, agentcore_client):
         """Reward function is invoked and result attached to StepResult."""
 
         class ContainsReward:
@@ -157,7 +157,7 @@ class TestCodeMode:
 
         env = CodeSandboxEnv(
             model_factory=model_factory,
-            boto3_session=boto3_session,
+            client=agentcore_client,
             mode=CodeMode.CODE,
             reward_fn=ContainsReward(),
         )
@@ -197,11 +197,11 @@ class TestTerminalMode:
 
 
 class TestCodeAndTerminalMode:
-    async def test_step_completes(self, model_factory, boto3_session):
+    async def test_step_completes(self, model_factory, agentcore_client):
         """Agent has both code and terminal tools available."""
         env = CodeSandboxEnv(
             model_factory=model_factory,
-            boto3_session=boto3_session,
+            client=agentcore_client,
             mode=CodeMode.CODE_AND_TERMINAL,
         )
         try:
@@ -220,11 +220,11 @@ class TestCodeAndTerminalMode:
 
 
 class TestToolLimit:
-    async def test_tool_iteration_limit(self, model_factory, boto3_session):
+    async def test_tool_iteration_limit(self, model_factory, agentcore_client):
         """Environment respects max_tool_iters."""
         env = CodeSandboxEnv(
             model_factory=model_factory,
-            boto3_session=boto3_session,
+            client=agentcore_client,
             mode=CodeMode.CODE,
             system_prompt=(
                 "You are a coding assistant. Always use the execute_code tool. "
@@ -243,7 +243,7 @@ class TestToolLimit:
         finally:
             await env.cleanup()
 
-    async def test_max_tool_calls(self, model_factory, boto3_session):
+    async def test_max_tool_calls(self, model_factory, agentcore_client):
         """Environment respects max_tool_calls (distinct from max_tool_iters).
 
         Note: parallel tool calls within a single iteration may exceed the limit
@@ -251,7 +251,7 @@ class TestToolLimit:
         """
         env = CodeSandboxEnv(
             model_factory=model_factory,
-            boto3_session=boto3_session,
+            client=agentcore_client,
             mode=CodeMode.CODE,
             system_prompt=(
                 "You are a coding assistant. Always use the execute_code tool. "

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import boto3
 
-from strands_env.utils.aws import check_credentials, get_session
+from strands_env.utils.aws import check_credentials, clear_session_cache, get_session
 
 
 class TestGetSession:
@@ -26,7 +26,7 @@ class TestGetSession:
 
     def setup_method(self):
         """Clear cache before each test."""
-        get_session.cache_clear()
+        clear_session_cache()
 
     def test_returns_session(self):
         """Should return a boto3 Session."""
@@ -70,7 +70,7 @@ class TestGetSessionWithRoleAssumption:
 
     def setup_method(self):
         """Clear cache before each test."""
-        get_session.cache_clear()
+        clear_session_cache()
 
     @patch("strands_env.utils.aws.boto3.client")
     @patch("botocore.session.get_session")


### PR DESCRIPTION
## Summary

- Add `get_client()` to `aws.py` that caches thread-safe boto3 clients, each with its own dedicated Session (avoids sharing the non-thread-safe `boto3.Session` across clients)
- Update `CodeInterpreterToolkit` to accept a `client` (boto3 low-level client) instead of a `boto3_session`
- Update `CodeSandboxEnv` to use `client` parameter and `get_client()` default

## Motivation

`boto3.Session` is [not thread-safe](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/session.html). Previously, `CodeInterpreterToolkit` accepted a shared cached Session and called `session.client()` in `__init__`. When many toolkit instances are created concurrently (e.g., concurrent rollouts in the Evaluator), this results in concurrent `session.client()` calls on the same Session — the exact unsafe pattern AWS warns about.

The fix caches the **client** (which is thread-safe) instead of the Session. Each `get_client()` call creates its own dedicated Session internally, uses it once to build the client, and then the Session is not shared. `RefreshableCredentials` still work because botocore's credential resolver on the client handles refresh transparently.

## Test plan

- [x] Unit tests pass (`pytest tests/unit/test_aws.py`)
- [x] Ruff lint passes
- [ ] Integration tests with AWS credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)