### PR TITLE
feat(env): wire max_tool_calls_per_turn through Environment and CLI

### DIFF
--- a/src/strands_env/cli/config.py
+++ b/src/strands_env/cli/config.py
@@ -70,7 +70,7 @@ class EnvConfig:
     system_prompt_path: Path | None = None
     max_tool_iters: int | None = None
     max_tool_calls: int | None = None
-    max_tool_calls_per_turn: int | None = None
+    max_parallel_tool_calls: int | None = None
     verbose: bool = False
 
     @property

--- a/src/strands_env/cli/eval.py
+++ b/src/strands_env/cli/eval.py
@@ -170,10 +170,10 @@ def list_cmd():
     help="Maximum tool calls per step.",
 )
 @click.option(
-    "--max-tool-calls-per-turn",
+    "--max-parallel-tool-calls",
     type=int,
     default=None,
-    help="Maximum tool calls per turn (excess are cancelled, not executed).",
+    help="Maximum parallel tool calls per model response (excess are cancelled, not executed).",
 )
 # Eval settings
 @click.option(
@@ -236,7 +236,7 @@ def run_cmd(
     system_prompt: Path | None,
     max_tool_iters: int | None,
     max_tool_calls: int | None,
-    max_tool_calls_per_turn: int | None,
+    max_parallel_tool_calls: int | None,
     # Eval
     n_samples_per_prompt: int,
     max_concurrency: int,
@@ -300,7 +300,7 @@ def run_cmd(
         system_prompt_path=system_prompt,
         max_tool_iters=max_tool_iters,
         max_tool_calls=max_tool_calls,
-        max_tool_calls_per_turn=max_tool_calls_per_turn,
+        max_parallel_tool_calls=max_parallel_tool_calls,
         verbose=False,  # Always False for eval
     )
     eval_config = EvalConfig(
@@ -359,7 +359,7 @@ def run_cmd(
             "system_prompt": resolved_system_prompt,
             "max_tool_iters": env_config.max_tool_iters,
             "max_tool_calls": env_config.max_tool_calls,
-            "max_tool_calls_per_turn": env_config.max_tool_calls_per_turn,
+            "max_parallel_tool_calls": env_config.max_parallel_tool_calls,
         },
         "eval": eval_config.to_dict(),
     }

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -52,14 +52,14 @@ class Environment:
         reward_fn: RewardFunction | None = None,
         max_tool_iters: int | None = None,
         max_tool_calls: int | None = None,
-        max_tool_calls_per_turn: int | None = None,
+        max_parallel_tool_calls: int | None = None,
         verbose: bool = False,
     ):
         self.model_factory = model_factory
         self.reward_fn = reward_fn
         self.max_tool_iters = max_tool_iters
         self.max_tool_calls = max_tool_calls
-        self.max_tool_calls_per_turn = max_tool_calls_per_turn
+        self.max_parallel_tool_calls = max_parallel_tool_calls
         self.verbose = verbose
 
         path = self.default_system_prompt_path
@@ -83,7 +83,7 @@ class Environment:
         tool_limiter = ToolLimiter(
             max_tool_iters=self.max_tool_iters,
             max_tool_calls=self.max_tool_calls,
-            max_tool_calls_per_turn=self.max_tool_calls_per_turn,
+            max_parallel_tool_calls=self.max_parallel_tool_calls,
         )
         model = self.model_factory()
         model.token_manager = TokenManager()

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -59,7 +59,7 @@ class TestEnvironmentInit:
         env = Environment(model_factory=model_factory)
         assert env.max_tool_iters is None
         assert env.max_tool_calls is None
-        assert env.max_tool_calls_per_turn is None
+        assert env.max_parallel_tool_calls is None
         assert env.verbose is False
         assert env.system_prompt is None
         assert env.reward_fn is None


### PR DESCRIPTION
## Summary
- Add `max_tool_calls_per_turn` parameter to `Environment.__init__` and pass it to `ToolLimiter`
- Add `cancelled_tool_calls` to step metrics from `tool_limiter.cancelled_tool_call_count`
- Add `max_tool_calls_per_turn` to `EnvConfig` and `--max-tool-calls-per-turn` CLI option in eval
- Update test assertion for new default

Depends on horizon-rl/strands-sglang#20.