### PR TITLE
fix(core): improve get_final_response for thinking models

### DIFF
--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -130,8 +130,8 @@ class Observation(BaseModel):
         )
         if text is None:
             return None
-        # Strip chain-of-thought traces (e.g. DeepSeek <think>...</think>).
-        think_end = text.rfind("</think>")
+        # Strip think block if any
+        think_end = text.rfind("</think>") # find the last </think> tag
         if think_end != -1:
             text = text[think_end + len("</think>") :].lstrip()
         return text or None

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -123,8 +123,18 @@ class Observation(BaseModel):
         if not messages or messages[-1].get("role") != "assistant":
             return None
         content = messages[-1].get("content", [])
-        texts = [block["text"] for block in content if isinstance(block, dict) and "text" in block]
-        return "\n".join(texts) if texts else None
+        # Take the last text block — the final textual output.
+        text = next(
+            (block["text"] for block in reversed(content) if isinstance(block, dict) and "text" in block),
+            None,
+        )
+        if text is None:
+            return None
+        # Strip chain-of-thought traces (e.g. DeepSeek <think>...</think>).
+        think_end = text.rfind("</think>")
+        if think_end != -1:
+            text = text[think_end + len("</think>") :].lstrip()
+        return text or None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -122,7 +122,27 @@ class TestObservation:
             {"role": "assistant", "content": [{"text": "hello"}, {"text": "world"}]},
         ]
         obs = Observation(messages=messages)
-        assert obs.final_response == "hello\nworld"
+        assert obs.final_response == "world"
+
+    def test_final_response_strips_think_tags(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": [{"text": "<think>reasoning here</think>The actual answer"}],
+            },
+        ]
+        obs = Observation(messages=messages)
+        assert obs.final_response == "The actual answer"
+
+    def test_final_response_strips_nested_think_tags(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": [{"text": "<think>first</think>middle<think>second</think>final answer"}],
+            },
+        ]
+        obs = Observation(messages=messages)
+        assert obs.final_response == "final answer"
 
     def test_final_response_no_assistant(self):
         messages = [{"role": "user", "content": [{"text": "hi"}]}]


### PR DESCRIPTION
## Summary
- Take only the last text block instead of joining all text blocks in `get_final_response`
- Strip chain-of-thought traces (everything before the last `</think>` tag) for thinking models that emit raw `<think>` tags in text content blocks

## Test plan
- [x] Unit tests pass (6/6 in `TestObservation`, including 2 new tests for think tag stripping)
- [x] Smoke-tested with a real GLM-4.5 thinking model on SGLang — confirmed `</think>` traces are correctly stripped from final response

🤖 Generated with [Claude Code](https://claude.com/claude-code)