### PR TITLE
refactor(eval): plumb judge_model_role_arn through chat_env factories

### DIFF
--- a/examples/eval/browsecomp/chat_env.py
+++ b/examples/eval/browsecomp/chat_env.py
@@ -25,7 +25,9 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
-        boto_session = get_session(region="us-west-2", profile_name=profile_name)
+        boto_session = get_session(
+            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+        )
         judge_models.append(
             bedrock_model_factory(
                 model_id=env_config.get("judge_model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0"),

--- a/examples/eval/frames/chat_env.py
+++ b/examples/eval/frames/chat_env.py
@@ -25,7 +25,9 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
-        boto_session = get_session(region="us-west-2", profile_name=profile_name)
+        boto_session = get_session(
+            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+        )
         judge_models.append(
             bedrock_model_factory(
                 model_id=env_config.get("judge_model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0"),

--- a/examples/eval/sealqa/chat_env.py
+++ b/examples/eval/sealqa/chat_env.py
@@ -25,7 +25,9 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
-        boto_session = get_session(region="us-west-2", profile_name=profile_name)
+        boto_session = get_session(
+            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+        )
         judge_models.append(
             bedrock_model_factory(
                 model_id=env_config.get("judge_model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0"),

--- a/examples/eval/simpleqa_verified/chat_env.py
+++ b/examples/eval/simpleqa_verified/chat_env.py
@@ -25,7 +25,9 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
-        boto_session = get_session(region="us-west-2", profile_name=profile_name)
+        boto_session = get_session(
+            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+        )
         judge_models.append(
             bedrock_model_factory(
                 model_id=env_config.get("judge_model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0"),


### PR DESCRIPTION
## Summary

- Wire `role_arn=env_config.get("judge_model_role_arn", None)` through the four chat-only benchmark env factories (`browsecomp`, `frames`, `sealqa`, `simpleqa_verified`) when constructing the judge model's `boto_session`.
- `get_session` already supports `role_arn` (it calls `create_assumed_role_session` with STS `AssumeRole` + refreshable credentials), so this is purely plumbing — no helper changes needed.
- Enables cross-account / assumed-role Bedrock access for judge models in eval runs without having to hand-edit the factories.