### PR TITLE
feat: async code interpreter + parallel test case reward

### DIFF
--- a/src/strands_env/rewards/__init__.py
+++ b/src/strands_env/rewards/__init__.py
@@ -14,10 +14,12 @@
 
 """Reward functions for Strands Agents Environments."""
 
+from .code_test_case_reward import CodeTestCaseReward
 from .llm_judge_reward import JudgmentFormat, LLMJudgeReward
 from .math_verify_reward import MathVerifyReward
 
 __all__ = [
+    "CodeTestCaseReward",
     "JudgmentFormat",
     "LLMJudgeReward",
     "MathVerifyReward",

--- a/src/strands_env/rewards/code_test_case_reward.py
+++ b/src/strands_env/rewards/code_test_case_reward.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Reward function for algorithmic coding problems with test case validation.
-
-Extracts Python code from agent response, executes it against hidden test cases,
-and returns reward as the proportion of test cases passed.
-"""
+"""Reward function for algorithmic coding problems with test case validation."""
 
 from __future__ import annotations
 
@@ -29,6 +25,7 @@ from typing_extensions import override
 
 from strands_env.core.types import Action, RewardFunction, RewardResult, StepResult
 from strands_env.tools import CodeInterpreterToolkit
+from strands_env.tools.code_interpreter import CodeInterpreterQuotas, create_aio_client
 
 logger = logging.getLogger(__name__)
 
@@ -39,34 +36,9 @@ DEFAULT_TEST_TIMEOUT = 180
 class CodeTestCaseReward(RewardFunction):
     r"""Reward based on proportion of hidden test cases passed.
 
-    Args:
-        extract_last_code_block: If `True`, use the last ```python block; else the first.
-        test_concurrency: Number of test cases to run in parallel per sample.
-        test_timeout: Per-test timeout in seconds. Tests exceeding this are counted as failed.
-        region_name: AWS region for bedrock-agentcore.
-        role_arn: AWS IAM role ARN for cross-account access.
-
-    Test Case Format:
-        `action.task_context.ground_truth` should be:
-        ```python
-        {
-            "inputs": ["test_input_1", "test_input_2", ...],
-            "outputs": ["expected_output_1", "expected_output_2", ...],
-        }
-        ```
-
-    Reward Calculation:
-        - `reward = passed / total`, in `[0.0, 1.0]`.
-        - Returns `0.0` if code cannot be extracted, ground truth is malformed,
-          or the batch of test cases fails with an unexpected exception.
-        - Individual execution errors or timeouts count as test failures.
-
-    Notes:
-        - Runs test cases in parallel across independent sandbox sessions
-          (no cross-test state leakage).
-        - Compares outputs with exact string match after stripping whitespace and
-          normalizing `\\r\\n` to `\\n`.
-        - Call `cleanup()` when done to close sandbox sessions.
+    Creates ONE shared aiobotocore client and passes it to all parallel
+    `CodeInterpreterToolkit` instances — avoids duplicate STS assume-role
+    calls and connection pool exhaustion.
     """
 
     def __init__(
@@ -80,34 +52,39 @@ class CodeTestCaseReward(RewardFunction):
         max_pool_connections: int = 1024,
         connect_timeout: int = 120,
         read_timeout: int = 120,
-        # Backward compat: ignored, aiobotocore manages its own client
         client: Any = None,
     ) -> None:
         """Initialize a `CodeTestCaseReward` instance."""
         self.extract_last_code_block = extract_last_code_block
         self._test_concurrency = test_concurrency
         self._test_timeout = test_timeout
-        self._toolkit_kwargs = {
+        self._client_kwargs = {
             "region_name": region_name,
             "role_arn": role_arn,
             "max_pool_connections": max_pool_connections,
             "connect_timeout": connect_timeout,
             "read_timeout": read_timeout,
         }
-        self._toolkits: list[CodeInterpreterToolkit] = [
-            CodeInterpreterToolkit(session_name=f"code-reward-{i}", **self._toolkit_kwargs)
-            for i in range(test_concurrency)
-        ]
+        self._shared_client: Any = None
+        self._toolkits: list[CodeInterpreterToolkit] | None = None
+
+    async def _ensure_toolkits(self) -> list[CodeInterpreterToolkit]:
+        """Lazy-init: create ONE shared client + N toolkits on first use."""
+        if self._toolkits is None:
+            self._shared_client = await create_aio_client(**self._client_kwargs)
+            shared_quotas = CodeInterpreterQuotas()
+            self._toolkits = [
+                CodeInterpreterToolkit(
+                    aio_client=self._shared_client,
+                    session_name=f"code-reward-{i}",
+                    quotas=shared_quotas,
+                )
+                for i in range(self._test_concurrency)
+            ]
+        return self._toolkits
 
     def extract_code(self, text: str) -> str | None:
-        """Extract Python code from a markdown code block.
-
-        Args:
-            text: Text that may contain ```python ... ``` blocks.
-
-        Returns:
-            Extracted code string, or `None` if no code block is found.
-        """
+        """Extract Python code from a markdown code block."""
         pattern = r"```python\s*\n(.*?)\n```"
         matches = re.findall(pattern, text, re.DOTALL | re.IGNORECASE)
         if not matches:
@@ -124,10 +101,11 @@ class CodeTestCaseReward(RewardFunction):
         expected_output: str,
         idx: int,
         sem: asyncio.Semaphore,
+        toolkits: list[CodeInterpreterToolkit],
     ) -> dict[str, Any]:
         """Execute a single test case with timeout, using a pooled toolkit."""
         async with sem:
-            toolkit = self._toolkits[idx % self._test_concurrency]
+            toolkit = toolkits[idx % self._test_concurrency]
             try:
                 wrapped = toolkit._wrap_code_with_stdin(code, test_input)
                 actual_output = await asyncio.wait_for(
@@ -149,9 +127,7 @@ class CodeTestCaseReward(RewardFunction):
 
     def compare_outputs(self, expected: str, actual: str) -> bool:
         """Return `True` if `actual` matches `expected` after whitespace normalization."""
-        expected_normalized = expected.strip().replace("\r\n", "\n")
-        actual_normalized = actual.strip().replace("\r\n", "\n")
-        return expected_normalized == actual_normalized
+        return expected.strip().replace("\r\n", "\n") == actual.strip().replace("\r\n", "\n")
 
     async def run_test_cases(
         self,
@@ -159,21 +135,15 @@ class CodeTestCaseReward(RewardFunction):
         test_inputs: list[str],
         test_outputs: list[str],
     ) -> tuple[int, int, list[dict[str, Any]]]:
-        """Run `code` against test cases in parallel with per-test timeout.
-
-        Uses `test_concurrency` independent sandbox sessions. Each test runs in
-        its own session — no cross-test state leakage.
-
-        Returns:
-            `(passed_count, total_count, per_test_results)`.
-        """
+        """Run `code` against test cases in parallel with per-test timeout."""
         if len(test_inputs) != len(test_outputs):
             logger.error("Mismatched test inputs/outputs lengths: %d vs %d", len(test_inputs), len(test_outputs))
             return 0, len(test_inputs), []
 
+        toolkits = await self._ensure_toolkits()
         sem = asyncio.Semaphore(self._test_concurrency)
         tasks = [
-            self._execute_one_test(code, inp, out, idx, sem)
+            self._execute_one_test(code, inp, out, idx, sem, toolkits)
             for idx, (inp, out) in enumerate(zip(test_inputs, test_outputs, strict=True))
         ]
         results = await asyncio.gather(*tasks)
@@ -199,10 +169,7 @@ class CodeTestCaseReward(RewardFunction):
         if not isinstance(ground_truth, dict):
             return RewardResult(
                 reward=0.0,
-                info={
-                    "reason": "invalid_ground_truth_format",
-                    "ground_truth_type": type(ground_truth).__name__,
-                },
+                info={"reason": "invalid_ground_truth_format", "ground_truth_type": type(ground_truth).__name__},
             )
 
         test_inputs = ground_truth.get("inputs", [])
@@ -210,11 +177,7 @@ class CodeTestCaseReward(RewardFunction):
         if not test_inputs or not test_outputs:
             return RewardResult(
                 reward=0.0,
-                info={
-                    "reason": "no_test_cases",
-                    "inputs_count": len(test_inputs),
-                    "outputs_count": len(test_outputs),
-                },
+                info={"reason": "no_test_cases", "inputs_count": len(test_inputs), "outputs_count": len(test_outputs)},
             )
 
         try:
@@ -239,9 +202,17 @@ class CodeTestCaseReward(RewardFunction):
         )
 
     async def cleanup(self) -> None:
-        """Release all sandbox sessions."""
-        for toolkit in self._toolkits:
+        """Release all sandbox sessions and the shared client."""
+        if self._toolkits:
+            for toolkit in self._toolkits:
+                try:
+                    await toolkit.cleanup()
+                except Exception:  # noqa: BLE001
+                    pass
+        if self._shared_client is not None:
             try:
-                await toolkit.cleanup()
+                await self._shared_client.__aexit__(None, None, None)
             except Exception:  # noqa: BLE001
                 pass
+            self._shared_client = None
+        self._toolkits = None

--- a/src/strands_env/rewards/code_test_case_reward.py
+++ b/src/strands_env/rewards/code_test_case_reward.py
@@ -1,0 +1,247 @@
+# Copyright 2025-2026 Horizon RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reward function for algorithmic coding problems with test case validation.
+
+Extracts Python code from agent response, executes it against hidden test cases,
+and returns reward as the proportion of test cases passed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+from typing_extensions import override
+
+from strands_env.core.types import Action, RewardFunction, RewardResult, StepResult
+from strands_env.tools import CodeInterpreterToolkit
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TEST_CONCURRENCY = 5
+DEFAULT_TEST_TIMEOUT = 180
+
+
+class CodeTestCaseReward(RewardFunction):
+    r"""Reward based on proportion of hidden test cases passed.
+
+    Args:
+        extract_last_code_block: If `True`, use the last ```python block; else the first.
+        test_concurrency: Number of test cases to run in parallel per sample.
+        test_timeout: Per-test timeout in seconds. Tests exceeding this are counted as failed.
+        region_name: AWS region for bedrock-agentcore.
+        role_arn: AWS IAM role ARN for cross-account access.
+
+    Test Case Format:
+        `action.task_context.ground_truth` should be:
+        ```python
+        {
+            "inputs": ["test_input_1", "test_input_2", ...],
+            "outputs": ["expected_output_1", "expected_output_2", ...],
+        }
+        ```
+
+    Reward Calculation:
+        - `reward = passed / total`, in `[0.0, 1.0]`.
+        - Returns `0.0` if code cannot be extracted, ground truth is malformed,
+          or the batch of test cases fails with an unexpected exception.
+        - Individual execution errors or timeouts count as test failures.
+
+    Notes:
+        - Runs test cases in parallel across independent sandbox sessions
+          (no cross-test state leakage).
+        - Compares outputs with exact string match after stripping whitespace and
+          normalizing `\\r\\n` to `\\n`.
+        - Call `cleanup()` when done to close sandbox sessions.
+    """
+
+    def __init__(
+        self,
+        extract_last_code_block: bool = True,
+        *,
+        test_concurrency: int = DEFAULT_TEST_CONCURRENCY,
+        test_timeout: int = DEFAULT_TEST_TIMEOUT,
+        region_name: str = "us-east-1",
+        role_arn: str | None = None,
+        max_pool_connections: int = 1024,
+        connect_timeout: int = 120,
+        read_timeout: int = 120,
+        # Backward compat: ignored, aiobotocore manages its own client
+        client: Any = None,
+    ) -> None:
+        """Initialize a `CodeTestCaseReward` instance."""
+        self.extract_last_code_block = extract_last_code_block
+        self._test_concurrency = test_concurrency
+        self._test_timeout = test_timeout
+        self._toolkit_kwargs = {
+            "region_name": region_name,
+            "role_arn": role_arn,
+            "max_pool_connections": max_pool_connections,
+            "connect_timeout": connect_timeout,
+            "read_timeout": read_timeout,
+        }
+        self._toolkits: list[CodeInterpreterToolkit] = [
+            CodeInterpreterToolkit(session_name=f"code-reward-{i}", **self._toolkit_kwargs)
+            for i in range(test_concurrency)
+        ]
+
+    def extract_code(self, text: str) -> str | None:
+        """Extract Python code from a markdown code block.
+
+        Args:
+            text: Text that may contain ```python ... ``` blocks.
+
+        Returns:
+            Extracted code string, or `None` if no code block is found.
+        """
+        pattern = r"```python\s*\n(.*?)\n```"
+        matches = re.findall(pattern, text, re.DOTALL | re.IGNORECASE)
+        if not matches:
+            pattern = r"```\s*\n(.*?)\n```"
+            matches = re.findall(pattern, text, re.DOTALL)
+        if not matches:
+            return None
+        return matches[-1] if self.extract_last_code_block else matches[0]
+
+    async def _execute_one_test(
+        self,
+        code: str,
+        test_input: str,
+        expected_output: str,
+        idx: int,
+        sem: asyncio.Semaphore,
+    ) -> dict[str, Any]:
+        """Execute a single test case with timeout, using a pooled toolkit."""
+        async with sem:
+            toolkit = self._toolkits[idx % self._test_concurrency]
+            try:
+                wrapped = toolkit._wrap_code_with_stdin(code, test_input)
+                actual_output = await asyncio.wait_for(
+                    toolkit.invoke("executeCode", {"code": wrapped, "language": "python"}),
+                    timeout=self._test_timeout,
+                )
+            except asyncio.TimeoutError:
+                actual_output = f"TIMEOUT: exceeded {self._test_timeout}s"
+            except Exception as e:  # noqa: BLE001
+                actual_output = f"EXECUTION_ERROR: {type(e).__name__}: {str(e)}"
+
+            is_passed = self.compare_outputs(expected_output, actual_output)
+            return {
+                "test_case": idx,
+                "passed": is_passed,
+                "expected": expected_output[:200],
+                "actual": actual_output[:200],
+            }
+
+    def compare_outputs(self, expected: str, actual: str) -> bool:
+        """Return `True` if `actual` matches `expected` after whitespace normalization."""
+        expected_normalized = expected.strip().replace("\r\n", "\n")
+        actual_normalized = actual.strip().replace("\r\n", "\n")
+        return expected_normalized == actual_normalized
+
+    async def run_test_cases(
+        self,
+        code: str,
+        test_inputs: list[str],
+        test_outputs: list[str],
+    ) -> tuple[int, int, list[dict[str, Any]]]:
+        """Run `code` against test cases in parallel with per-test timeout.
+
+        Uses `test_concurrency` independent sandbox sessions. Each test runs in
+        its own session — no cross-test state leakage.
+
+        Returns:
+            `(passed_count, total_count, per_test_results)`.
+        """
+        if len(test_inputs) != len(test_outputs):
+            logger.error("Mismatched test inputs/outputs lengths: %d vs %d", len(test_inputs), len(test_outputs))
+            return 0, len(test_inputs), []
+
+        sem = asyncio.Semaphore(self._test_concurrency)
+        tasks = [
+            self._execute_one_test(code, inp, out, idx, sem)
+            for idx, (inp, out) in enumerate(zip(test_inputs, test_outputs, strict=True))
+        ]
+        results = await asyncio.gather(*tasks)
+
+        passed = sum(1 for r in results if r["passed"])
+        return passed, len(test_inputs), list(results)
+
+    @override
+    async def compute(self, action: Action, step_result: StepResult) -> RewardResult:
+        """Compute reward based on test case pass rate."""
+        content = step_result.observation.final_response
+        if content is None:
+            return RewardResult(reward=0.0, info={"reason": "no_final_response"})
+
+        code = self.extract_code(content)
+        if code is None:
+            return RewardResult(
+                reward=0.0,
+                info={"reason": "no_code_block_found", "response_sample": content[:500]},
+            )
+
+        ground_truth = action.task_context.ground_truth
+        if not isinstance(ground_truth, dict):
+            return RewardResult(
+                reward=0.0,
+                info={
+                    "reason": "invalid_ground_truth_format",
+                    "ground_truth_type": type(ground_truth).__name__,
+                },
+            )
+
+        test_inputs = ground_truth.get("inputs", [])
+        test_outputs = ground_truth.get("outputs", [])
+        if not test_inputs or not test_outputs:
+            return RewardResult(
+                reward=0.0,
+                info={
+                    "reason": "no_test_cases",
+                    "inputs_count": len(test_inputs),
+                    "outputs_count": len(test_outputs),
+                },
+            )
+
+        try:
+            passed, total, test_results = await self.run_test_cases(code, test_inputs, test_outputs)
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to run test cases: %s: %s", type(e).__name__, str(e))
+            return RewardResult(
+                reward=0.0,
+                info={"reason": "test_execution_failed", "error": f"{type(e).__name__}: {str(e)}"},
+            )
+
+        reward = passed / total if total > 0 else 0.0
+        return RewardResult(
+            reward=reward,
+            info={
+                "passed": passed,
+                "total": total,
+                "pass_rate": reward,
+                "code_extracted": code[:500],
+                "test_results": test_results[:5],
+            },
+        )
+
+    async def cleanup(self) -> None:
+        """Release all sandbox sessions."""
+        for toolkit in self._toolkits:
+            try:
+                await toolkit.cleanup()
+            except Exception:  # noqa: BLE001
+                pass

--- a/src/strands_env/tools/code_interpreter.py
+++ b/src/strands_env/tools/code_interpreter.py
@@ -30,6 +30,49 @@ from strands import tool
 logger = logging.getLogger(__name__)
 
 
+async def create_aio_client(
+    region_name: str = "us-east-1",
+    role_arn: str | None = None,
+    max_pool_connections: int = 1024,
+    connect_timeout: int = 120,
+    read_timeout: int = 120,
+) -> Any:
+    """Create a shared aiobotocore client for bedrock-agentcore.
+
+    Call this ONCE and pass the result to all `CodeInterpreterToolkit` instances.
+    """
+    import aiobotocore.session
+    from botocore.config import Config
+
+    session = aiobotocore.session.get_session()
+    config = Config(
+        max_pool_connections=max_pool_connections,
+        connect_timeout=connect_timeout,
+        read_timeout=read_timeout,
+        retries={"max_attempts": 3, "mode": "adaptive"},
+    )
+
+    kwargs: dict[str, Any] = {
+        "service_name": "bedrock-agentcore",
+        "region_name": region_name,
+        "config": config,
+    }
+
+    if role_arn:
+        sts_session = aiobotocore.session.get_session()
+        async with sts_session.create_client("sts", region_name=region_name) as sts:
+            creds = await sts.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName="strands-env-code-interpreter",
+            )
+        credentials = creds["Credentials"]
+        kwargs["aws_access_key_id"] = credentials["AccessKeyId"]
+        kwargs["aws_secret_access_key"] = credentials["SecretAccessKey"]
+        kwargs["aws_session_token"] = credentials["SessionToken"]
+
+    return await session.create_client(**kwargs).__aenter__()
+
+
 class CodeInterpreterQuotas:
     """Shared AWS quotas for Code Interpreter API operations.
 
@@ -92,6 +135,8 @@ class CodeInterpreterToolkit:
         - Provides `execute_code` and `execute_command` tools for running Python code
           and shell commands in a sandboxed environment.
         - Uses aiobotocore for fully async I/O — no threads, no GIL contention.
+        - Pass a shared `aio_client` (from `create_aio_client()`) to avoid creating
+          duplicate clients and STS assume-role calls.
         - Uses a single shared agentcore session through session ID. Call
           `cleanup` when done to close the session.
     """
@@ -100,79 +145,22 @@ class CodeInterpreterToolkit:
 
     def __init__(
         self,
-        client: Any = None,
+        aio_client: Any,
         session_name: str = "strands-env",
         quotas: CodeInterpreterQuotas | None = None,
-        *,
-        region_name: str = "us-east-1",
-        role_arn: str | None = None,
-        max_pool_connections: int = 1024,
-        connect_timeout: int = 120,
-        read_timeout: int = 120,
     ):
         """Initialize a `CodeInterpreterToolkit` instance.
 
         Args:
-            client: Ignored (kept for backward compatibility). aiobotocore client is managed internally.
+            aio_client: Shared aiobotocore client from `create_aio_client()`.
             session_name: Name for the code interpreter session.
             quotas: Shared quotas for rate limiting and session concurrency.
-            region_name: AWS region for the bedrock-agentcore service.
-            role_arn: AWS IAM role ARN for cross-account access.
-            max_pool_connections: Maximum number of connections in the aiohttp pool.
-            connect_timeout: Connection timeout in seconds.
-            read_timeout: Read timeout in seconds.
         """
         self.session_name = session_name
         self.session_id: str | None = None
         self.quotas = quotas or CodeInterpreterQuotas()
         self._session_lock = asyncio.Lock()
-
-        self._region_name = region_name
-        self._role_arn = role_arn
-        self._max_pool_connections = max_pool_connections
-        self._connect_timeout = connect_timeout
-        self._read_timeout = read_timeout
-        self._aio_client: Any = None
-        self._aio_session: Any = None
-
-    async def _get_aio_client(self) -> Any:
-        """Get or create the aiobotocore client (lazy init)."""
-        if self._aio_client is None:
-            import aiobotocore.session
-            from botocore.config import Config
-
-            self._aio_session = aiobotocore.session.get_session()
-
-            config = Config(
-                max_pool_connections=self._max_pool_connections,
-                connect_timeout=self._connect_timeout,
-                read_timeout=self._read_timeout,
-                retries={"max_attempts": 3, "mode": "adaptive"},
-            )
-
-            kwargs: dict[str, Any] = {
-                "service_name": "bedrock-agentcore",
-                "region_name": self._region_name,
-                "config": config,
-            }
-
-            if self._role_arn:
-                import aiobotocore.session as aio_session
-
-                sts_session = aio_session.get_session()
-                async with sts_session.create_client("sts", region_name=self._region_name) as sts:
-                    creds = await sts.assume_role(
-                        RoleArn=self._role_arn,
-                        RoleSessionName="strands-env-code-interpreter",
-                    )
-                credentials = creds["Credentials"]
-                kwargs["aws_access_key_id"] = credentials["AccessKeyId"]
-                kwargs["aws_secret_access_key"] = credentials["SecretAccessKey"]
-                kwargs["aws_session_token"] = credentials["SessionToken"]
-
-            self._aio_client = await self._aio_session.create_client(**kwargs).__aenter__()
-
-        return self._aio_client
+        self._client = aio_client
 
     async def start_session(self) -> None:
         """Start a code interpreter session if not already started (async, coroutine-safe)."""
@@ -184,8 +172,7 @@ class CodeInterpreterToolkit:
                 await self.quotas._acquire_semaphore_with_warning("Session")
                 await self.quotas._acquire_limiter_with_warning(self.quotas.start_limiter, "StartSession")
                 try:
-                    client = await self._get_aio_client()
-                    response = await client.start_code_interpreter_session(
+                    response = await self._client.start_code_interpreter_session(
                         codeInterpreterIdentifier=self.CODE_INTERPRETER_ID,
                         name=self.session_name,
                         sessionTimeoutSeconds=3600,
@@ -204,15 +191,7 @@ class CodeInterpreterToolkit:
 
     @classmethod
     def _wrap_code_with_stdin(cls, code: str, stdin: str) -> str:
-        """Wrap user code so `input()` and `sys.stdin` read from `stdin`.
-
-        Args:
-            code: User Python code.
-            stdin: Newline-separated stdin payload.
-
-        Returns:
-            Wrapped code ready for `executeCode`.
-        """
+        """Wrap user code so `input()` and `sys.stdin` read from `stdin`."""
         escaped_stdin = stdin.replace("\\", "\\\\").replace("'''", "\\'\\'\\'")
         return f"""import sys
 from io import StringIO
@@ -242,14 +221,12 @@ finally:
         """Invoke the code interpreter and return parsed response."""
         await self.start_session()
         await self.quotas._acquire_limiter_with_warning(self.quotas.invoke_limiter, "InvokeCodeInterpreter")
-        client = await self._get_aio_client()
-        response = await client.invoke_code_interpreter(
+        response = await self._client.invoke_code_interpreter(
             codeInterpreterIdentifier=self.CODE_INTERPRETER_ID,
             sessionId=self.session_id,
             name=name,
             arguments=arguments,
         )
-        # Parse the `EventStream` response from `invoke_code_interpreter`.
         stream = response.get("stream")
         if stream is not None:
             async for event in stream:
@@ -276,61 +253,31 @@ finally:
 
     @tool
     async def execute_code(self, code: str) -> str:
-        """Execute Python code and return the result.
-
-        Args:
-            code: The Python code to execute.
-
-        Returns:
-            Execution output text or error message.
-        """
+        """Execute Python code and return the result."""
         return await self.invoke("executeCode", {"code": code, "language": "python"})
 
     @tool
     async def execute_code_with_stdin(self, code: str, stdin: str) -> str:
-        """Execute Python code with stdin input and return the result.
-
-        Args:
-            code: The Python code to execute.
-            stdin: Input to provide via stdin (newline-separated for multiple `input()` calls).
-
-        Returns:
-            Execution output text or error message.
-        """
+        """Execute Python code with stdin input and return the result."""
         wrapped_code = self._wrap_code_with_stdin(code, stdin)
         return await self.invoke("executeCode", {"code": wrapped_code, "language": "python"})
 
     @tool
     async def execute_command(self, command: str) -> str:
-        """Execute a shell command and return the result.
-
-        Args:
-            command: The shell command to execute.
-
-        Returns:
-            Execution output text or error message.
-        """
+        """Execute a shell command and return the result."""
         return await self.invoke("executeCommand", {"command": command})
 
     async def cleanup(self) -> None:
-        """Clean up code interpreter session and aiobotocore client."""
+        """Clean up code interpreter session (does NOT close the shared client)."""
         if self.session_id:
             await self.quotas._acquire_limiter_with_warning(self.quotas.stop_limiter, "StopSession")
             try:
-                client = await self._get_aio_client()
-                await client.stop_code_interpreter_session(
+                await self._client.stop_code_interpreter_session(
                     codeInterpreterIdentifier=self.CODE_INTERPRETER_ID,
                     sessionId=self.session_id,
                 )
             except Exception:
-                pass  # Ignore cleanup errors
+                pass
             finally:
                 self.quotas.session_semaphore.release()
             self.session_id = None
-
-        if self._aio_client is not None:
-            try:
-                await self._aio_client.__aexit__(None, None, None)
-            except Exception:
-                pass
-            self._aio_client = None

--- a/src/strands_env/tools/code_interpreter.py
+++ b/src/strands_env/tools/code_interpreter.py
@@ -12,20 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Code sandbox toolkit using AWS Bedrock AgentCore Code Interpreter."""
+"""Code sandbox toolkit using AWS Bedrock AgentCore Code Interpreter.
+
+Uses aiobotocore for fully async I/O — no threads, no GIL contention.
+"""
 
 from __future__ import annotations
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
-from functools import partial
-from typing import TYPE_CHECKING, Any
+import logging
+import time
+from typing import Any
 
 from aiolimiter import AsyncLimiter
 from strands import tool
 
-if TYPE_CHECKING:
-    from strands_env.utils.aws import BotoClient
+logger = logging.getLogger(__name__)
 
 
 class CodeInterpreterQuotas:
@@ -34,20 +36,18 @@ class CodeInterpreterQuotas:
     Notes:
         - Create one instance and pass it to all `CodeInterpreterToolkit` instances
         to enforce account-wide limits across concurrent sessions.
-        - Manages three concerns:
+        - Manages two concerns:
             - Session semaphore: caps concurrent sessions (`session_concurrency`).
             - Rate limiters: caps API request initiation rate for start/invoke/stop
               (AWS TPS quotas) to prevent throttling errors.
-            - Thread pool executor: sized to match `session_concurrency` so each session can
-              have one in-flight blocking boto3 call without starving others.
 
     References:
         - [AWS Bedrock AgentCore default quotas](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/bedrock-agentcore-limits.html)
     """
 
-    DEFAULT_SESSION_CONCURRENCY = 1000
+    DEFAULT_SESSION_CONCURRENCY = 3000
     DEFAULT_START_TPS = 30
-    DEFAULT_INVOKE_TPS = 30
+    DEFAULT_INVOKE_TPS = 300
     DEFAULT_STOP_TPS = 30
 
     def __init__(
@@ -62,11 +62,27 @@ class CodeInterpreterQuotas:
         self.start_limiter = AsyncLimiter(start_tps, time_period=1)
         self.invoke_limiter = AsyncLimiter(invoke_tps, time_period=1)
         self.stop_limiter = AsyncLimiter(stop_tps, time_period=1)
-        self.executor = ThreadPoolExecutor(max_workers=session_concurrency)
 
-    def to_thread(self, func: Any, /, *args: Any, **kwargs: Any) -> Any:
-        """Run a blocking function in the quotas thread pool (or default pool if no quotas)."""
-        return asyncio.get_running_loop().run_in_executor(self.executor, partial(func, *args, **kwargs))
+    async def _acquire_semaphore_with_warning(self, name: str) -> None:
+        """Acquire the session semaphore, logging a warning if it blocked."""
+        start = time.time()
+        await self.session_semaphore.acquire()
+        elapsed = time.time() - start
+        if elapsed > 0.001:
+            logger.warning(
+                "%s semaphore hit limit (max: %d), waited %.3fs",
+                name,
+                self.session_semaphore._value + 1,
+                elapsed,
+            )
+
+    async def _acquire_limiter_with_warning(self, limiter: AsyncLimiter, name: str) -> None:
+        """Acquire `limiter`, logging a warning if it blocked."""
+        start = time.time()
+        await limiter.acquire()
+        elapsed = time.time() - start
+        if elapsed > 0.001:
+            logger.warning("%s rate limiter hit limit, waited %.3fs", name, elapsed)
 
 
 class CodeInterpreterToolkit:
@@ -75,6 +91,7 @@ class CodeInterpreterToolkit:
     Notes:
         - Provides `execute_code` and `execute_command` tools for running Python code
           and shell commands in a sandboxed environment.
+        - Uses aiobotocore for fully async I/O — no threads, no GIL contention.
         - Uses a single shared agentcore session through session ID. Call
           `cleanup` when done to close the session.
     """
@@ -83,38 +100,92 @@ class CodeInterpreterToolkit:
 
     def __init__(
         self,
-        client: BotoClient,
+        client: Any = None,
         session_name: str = "strands-env",
         quotas: CodeInterpreterQuotas | None = None,
+        *,
+        region_name: str = "us-east-1",
+        role_arn: str | None = None,
+        max_pool_connections: int = 1024,
+        connect_timeout: int = 120,
+        read_timeout: int = 120,
     ):
         """Initialize a `CodeInterpreterToolkit` instance.
 
         Args:
-            client: boto3 client for bedrock-agentcore service.
+            client: Ignored (kept for backward compatibility). aiobotocore client is managed internally.
             session_name: Name for the code interpreter session.
-            quotas: Shared quotas for rate limiting, session concurrency, and thread pool.
-                Create one `CodeInterpreterQuotas` instance and pass it to all toolkit
-                instances to enforce account-wide limits.
+            quotas: Shared quotas for rate limiting and session concurrency.
+            region_name: AWS region for the bedrock-agentcore service.
+            role_arn: AWS IAM role ARN for cross-account access.
+            max_pool_connections: Maximum number of connections in the aiohttp pool.
+            connect_timeout: Connection timeout in seconds.
+            read_timeout: Read timeout in seconds.
         """
         self.session_name = session_name
-        self.client = client
         self.session_id: str | None = None
         self.quotas = quotas or CodeInterpreterQuotas()
         self._session_lock = asyncio.Lock()
 
+        self._region_name = region_name
+        self._role_arn = role_arn
+        self._max_pool_connections = max_pool_connections
+        self._connect_timeout = connect_timeout
+        self._read_timeout = read_timeout
+        self._aio_client: Any = None
+        self._aio_session: Any = None
+
+    async def _get_aio_client(self) -> Any:
+        """Get or create the aiobotocore client (lazy init)."""
+        if self._aio_client is None:
+            import aiobotocore.session
+            from botocore.config import Config
+
+            self._aio_session = aiobotocore.session.get_session()
+
+            config = Config(
+                max_pool_connections=self._max_pool_connections,
+                connect_timeout=self._connect_timeout,
+                read_timeout=self._read_timeout,
+                retries={"max_attempts": 3, "mode": "adaptive"},
+            )
+
+            kwargs: dict[str, Any] = {
+                "service_name": "bedrock-agentcore",
+                "region_name": self._region_name,
+                "config": config,
+            }
+
+            if self._role_arn:
+                import aiobotocore.session as aio_session
+
+                sts_session = aio_session.get_session()
+                async with sts_session.create_client("sts", region_name=self._region_name) as sts:
+                    creds = await sts.assume_role(
+                        RoleArn=self._role_arn,
+                        RoleSessionName="strands-env-code-interpreter",
+                    )
+                credentials = creds["Credentials"]
+                kwargs["aws_access_key_id"] = credentials["AccessKeyId"]
+                kwargs["aws_secret_access_key"] = credentials["SecretAccessKey"]
+                kwargs["aws_session_token"] = credentials["SessionToken"]
+
+            self._aio_client = await self._aio_session.create_client(**kwargs).__aenter__()
+
+        return self._aio_client
+
     async def start_session(self) -> None:
-        """Start a code interpreter session if not already started (async, thread-safe)."""
+        """Start a code interpreter session if not already started (async, coroutine-safe)."""
         if self.session_id is None:
             async with self._session_lock:
-                # Double-check after acquiring lock as another coroutine may have set it
                 if self.session_id is not None:
                     return  # type: ignore[unreachable]
 
-                await self.quotas.session_semaphore.acquire()
-                await self.quotas.start_limiter.acquire()
+                await self.quotas._acquire_semaphore_with_warning("Session")
+                await self.quotas._acquire_limiter_with_warning(self.quotas.start_limiter, "StartSession")
                 try:
-                    response = await self.quotas.to_thread(
-                        self.client.start_code_interpreter_session,
+                    client = await self._get_aio_client()
+                    response = await client.start_code_interpreter_session(
                         codeInterpreterIdentifier=self.CODE_INTERPRETER_ID,
                         name=self.session_name,
                         sessionTimeoutSeconds=3600,
@@ -124,37 +195,82 @@ class CodeInterpreterToolkit:
                     raise
                 self.session_id = response["sessionId"]
 
+    @staticmethod
+    def _indent_code(code: str, spaces: int) -> str:
+        """Indent each non-empty line of `code` by `spaces` spaces."""
+        indent = " " * spaces
+        lines = code.split("\n")
+        return "\n".join(indent + line if line.strip() else line for line in lines)
+
+    @classmethod
+    def _wrap_code_with_stdin(cls, code: str, stdin: str) -> str:
+        """Wrap user code so `input()` and `sys.stdin` read from `stdin`.
+
+        Args:
+            code: User Python code.
+            stdin: Newline-separated stdin payload.
+
+        Returns:
+            Wrapped code ready for `executeCode`.
+        """
+        escaped_stdin = stdin.replace("\\", "\\\\").replace("'''", "\\'\\'\\'")
+        return f"""import sys
+from io import StringIO
+import builtins
+
+_input_lines = '''{escaped_stdin}'''.split('\\n')
+_input_index = [0]
+
+_original_input = builtins.input
+def _mock_input(prompt=''):
+    if _input_index[0] >= len(_input_lines):
+        raise EOFError('No more input available')
+    line = _input_lines[_input_index[0]]
+    _input_index[0] += 1
+    return line
+
+builtins.input = _mock_input
+sys.stdin = StringIO('''{escaped_stdin}''')
+
+try:
+{cls._indent_code(code, 4)}
+finally:
+    builtins.input = _original_input
+"""
+
     async def invoke(self, name: str, arguments: dict[str, Any]) -> str:
         """Invoke the code interpreter and return parsed response."""
         await self.start_session()
-        await self.quotas.invoke_limiter.acquire()
-        response = await self.quotas.to_thread(
-            self.client.invoke_code_interpreter,
+        await self.quotas._acquire_limiter_with_warning(self.quotas.invoke_limiter, "InvokeCodeInterpreter")
+        client = await self._get_aio_client()
+        response = await client.invoke_code_interpreter(
             codeInterpreterIdentifier=self.CODE_INTERPRETER_ID,
             sessionId=self.session_id,
             name=name,
             arguments=arguments,
         )
         # Parse the `EventStream` response from `invoke_code_interpreter`.
-        for event in response.get("stream", []):
-            if "result" in event:
-                content = event["result"].get("content", [])
-                if isinstance(content, list):
-                    texts = [c.get("text", "") for c in content if c.get("type") == "text"]
-                    return "\n".join(texts) if texts else str(content)
-                return str(content)
+        stream = response.get("stream")
+        if stream is not None:
+            async for event in stream:
+                if "result" in event:
+                    content = event["result"].get("content", [])
+                    if isinstance(content, list):
+                        texts = [c.get("text", "") for c in content if c.get("type") == "text"]
+                        return "\n".join(texts) if texts else ""
+                    return str(content)
 
-            for key in (
-                "accessDeniedException",
-                "conflictException",
-                "internalServerException",
-                "resourceNotFoundException",
-                "serviceQuotaExceededException",
-                "throttlingException",
-                "validationException",
-            ):
-                if key in event:
-                    return f"{key}: {event[key].get('message', key)}"
+                for key in (
+                    "accessDeniedException",
+                    "conflictException",
+                    "internalServerException",
+                    "resourceNotFoundException",
+                    "serviceQuotaExceededException",
+                    "throttlingException",
+                    "validationException",
+                ):
+                    if key in event:
+                        return f"{key}: {event[key].get('message', key)}"
 
         return "No result returned."
 
@@ -171,6 +287,20 @@ class CodeInterpreterToolkit:
         return await self.invoke("executeCode", {"code": code, "language": "python"})
 
     @tool
+    async def execute_code_with_stdin(self, code: str, stdin: str) -> str:
+        """Execute Python code with stdin input and return the result.
+
+        Args:
+            code: The Python code to execute.
+            stdin: Input to provide via stdin (newline-separated for multiple `input()` calls).
+
+        Returns:
+            Execution output text or error message.
+        """
+        wrapped_code = self._wrap_code_with_stdin(code, stdin)
+        return await self.invoke("executeCode", {"code": wrapped_code, "language": "python"})
+
+    @tool
     async def execute_command(self, command: str) -> str:
         """Execute a shell command and return the result.
 
@@ -183,12 +313,12 @@ class CodeInterpreterToolkit:
         return await self.invoke("executeCommand", {"command": command})
 
     async def cleanup(self) -> None:
-        """Clean up code interpreter session."""
+        """Clean up code interpreter session and aiobotocore client."""
         if self.session_id:
-            await self.quotas.stop_limiter.acquire()
+            await self.quotas._acquire_limiter_with_warning(self.quotas.stop_limiter, "StopSession")
             try:
-                await self.quotas.to_thread(
-                    self.client.stop_code_interpreter_session,
+                client = await self._get_aio_client()
+                await client.stop_code_interpreter_session(
                     codeInterpreterIdentifier=self.CODE_INTERPRETER_ID,
                     sessionId=self.session_id,
                 )
@@ -197,3 +327,10 @@ class CodeInterpreterToolkit:
             finally:
                 self.quotas.session_semaphore.release()
             self.session_id = None
+
+        if self._aio_client is not None:
+            try:
+                await self._aio_client.__aexit__(None, None, None)
+            except Exception:
+                pass
+            self._aio_client = None


### PR DESCRIPTION
Replace ThreadPoolExecutor + sync boto3 with aiobotocore for fully async I/O in CodeInterpreterToolkit. Eliminates GIL contention that caused Ray actor heartbeat misses and training crashes under high concurrency (512+ concurrent reward computations).

Add CodeTestCaseReward for competitive coding RL training: extracts Python code from model responses, runs against hidden test cases in parallel (5-way concurrent sandbox sessions with 180s per-test timeout), returns pass rate as reward.

Key changes:
- CodeInterpreterToolkit: aiobotocore async client (lazy init), zero threads
- CodeInterpreterQuotas: removed ThreadPoolExecutor, kept semaphore + rate limiters
- CodeTestCaseReward: parallel test execution via asyncio.gather, per-test timeout
- Fixed empty stdout bug (was returning literal "[]" instead of "")
- Added execute_code_with_stdin for stdin-piped code execution