### PR TITLE
refactor(web_search): unified search entry point + provider type alias

### DIFF
--- a/src/strands_env/environments/web_search/env.py
+++ b/src/strands_env/environments/web_search/env.py
@@ -16,7 +16,6 @@
 
 import asyncio
 from pathlib import Path
-from typing import Literal
 
 from typing_extensions import Unpack, override
 
@@ -24,14 +23,14 @@ from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.core.models import ModelFactory
 from strands_env.core.types import RewardFunction
 from strands_env.tools.web_scraper import WebScraperToolkit
-from strands_env.tools.web_search import WebSearchToolkit
+from strands_env.tools.web_search import WebSearchAPIProvider, WebSearchToolkit
 
 
 class WebSearchConfig(EnvironmentConfig, total=False):
     """Serializable configuration for `WebSearchEnv`."""
 
     # Search
-    search_provider: Literal["serper", "google"]
+    search_provider: WebSearchAPIProvider
     search_timeout: int
     blocked_domains: list[str]
 
@@ -59,13 +58,13 @@ class WebSearchEnv(Environment):
         """Initialize a `WebSearchEnv` instance."""
         super().__init__(model_factory=model_factory, reward_fn=reward_fn, **config)  # type: ignore[misc]
 
-        provider: str = self.config.get("search_provider", "serper")
         self.search_toolkit = WebSearchToolkit(
             timeout=int(self.config.get("search_timeout", 10)),
             concurrency=search_concurrency,
             blocked_domains=self.config.get("blocked_domains"),  # type: ignore[arg-type]
+            api_provider=self.config.get("search_provider", "serper"),
         )
-        self.search_tool = getattr(self.search_toolkit, f"{provider}_search")
+        self.search_tool = self.search_toolkit.search
 
         self.scrape_tool = None
         self.scraper_toolkit: WebScraperToolkit | None = None

--- a/src/strands_env/tools/web_search.py
+++ b/src/strands_env/tools/web_search.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import aiohttp
 from strands import tool
@@ -34,6 +34,8 @@ MAX_RESULTS = 10
 
 GOOGLE_SERPER_DEV_URL = "https://google.serper.dev/search"
 GOOGLE_CUSTOM_SEARCH_URL = "https://www.googleapis.com/customsearch/v1"
+
+WebSearchAPIProvider: TypeAlias = Literal["serper", "google"]
 
 
 class WebSearchToolkit:
@@ -51,7 +53,7 @@ class WebSearchToolkit:
         timeout: int = DEFAULT_TIMEOUT,
         concurrency: asyncio.Semaphore | int = DEFAULT_MAX_CONCURRENCY,
         blocked_domains: list[str] | None = None,
-        api_provider: Literal["serper", "google"] = "serper",
+        api_provider: WebSearchAPIProvider = "serper",
     ):
         """Initialize a `WebSearchToolkit` instance.
 
@@ -59,7 +61,7 @@ class WebSearchToolkit:
             timeout: HTTP request timeout in seconds.
             concurrency: Semaphore or max concurrent requests for API rate limiting.
             blocked_domains: Domains to exclude from results (e.g. `["huggingface.co"]`).
-            api_provider: The API provider to use.
+            api_provider: The API provider to use. Defaults to `"serper"`.
         """
         self.timeout = timeout
         self.semaphore = concurrency if isinstance(concurrency, asyncio.Semaphore) else asyncio.Semaphore(concurrency)

--- a/src/strands_env/tools/web_search.py
+++ b/src/strands_env/tools/web_search.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from typing import Literal
 
 import aiohttp
 from strands import tool
@@ -50,6 +51,7 @@ class WebSearchToolkit:
         timeout: int = DEFAULT_TIMEOUT,
         concurrency: asyncio.Semaphore | int = DEFAULT_MAX_CONCURRENCY,
         blocked_domains: list[str] | None = None,
+        api_provider: Literal["serper", "google"] = "serper",
     ):
         """Initialize a `WebSearchToolkit` instance.
 
@@ -57,10 +59,12 @@ class WebSearchToolkit:
             timeout: HTTP request timeout in seconds.
             concurrency: Semaphore or max concurrent requests for API rate limiting.
             blocked_domains: Domains to exclude from results (e.g. `["huggingface.co"]`).
+            api_provider: The API provider to use.
         """
         self.timeout = timeout
         self.semaphore = concurrency if isinstance(concurrency, asyncio.Semaphore) else asyncio.Semaphore(concurrency)
         self.blocked_domains = blocked_domains or []
+        self.api_provider = api_provider
         self._session: aiohttp.ClientSession | None = None
 
     def _get_session(self) -> aiohttp.ClientSession:
@@ -149,7 +153,7 @@ class WebSearchToolkit:
 
         Args:
             query: The search query.
-            top_k: Number of results to return (max 10).
+            top_k: Number of results to return.
 
         Returns:
             Search results with title, URL, and snippet for each result.
@@ -176,3 +180,26 @@ class WebSearchToolkit:
         except Exception as e:
             logger.error("[google_search] error: %s", e)
             return f"Search failed: {e}."
+
+    # ------------------------------------------------------------------
+    # Unified entry point
+    # ------------------------------------------------------------------
+
+    @tool
+    async def search(self, query: str, top_k: int = 5) -> str:
+        """Search the web.
+
+        Args:
+            query: The search query.
+            top_k: Number of results to return.
+
+        Returns:
+            Search results with title, URL, and snippet for each result.
+        """
+        match self.api_provider:
+            case "serper":
+                return await self.serper_search(query, top_k)
+            case "google":
+                return await self.google_search(query, top_k)
+            case _:
+                raise ValueError(f"Invalid API provider: {self.api_provider}")


### PR DESCRIPTION
## Summary
- Add a unified `search` tool on `WebSearchToolkit` that dispatches to the configured provider via `match/case`. `serper_search` and `google_search` remain `@tool`-decorated and usable standalone.
- Introduce `WebSearchAPIProvider: TypeAlias = Literal["serper", "google"]` as the single source of truth for provider names, shared between the toolkit and `WebSearchConfig`.
- `WebSearchEnv` now passes `api_provider` into the toolkit and exposes `self.search_toolkit.search`, replacing the `getattr(toolkit, f"{provider}_search")` pattern.

## Test plan
- [x] `ruff check src/` + `ruff format --check src/`
- [x] `pytest tests/unit/ -v` (140 passed, 2 skipped)
- [ ] Smoke-test `WebSearchEnv` against a real Serper key end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)