### PR TITLE
fix(web_search): inline get_tools return to fix mypy

### DIFF
--- a/src/strands_env/environments/web_search/env.py
+++ b/src/strands_env/environments/web_search/env.py
@@ -82,10 +82,9 @@ class WebSearchEnv(Environment):
     @override
     def get_tools(self) -> list:
         """Return search and optionally scrape tools."""
-        tools = [self.search_tool]
         if self.scrape_tool is not None:
-            tools.append(self.scrape_tool)
-        return tools
+            return [self.search_tool, self.scrape_tool]
+        return [self.search_tool]
 
     async def cleanup(self) -> None:
         """Close shared HTTP sessions for all toolkits."""


### PR DESCRIPTION
## Summary
- `WebSearchEnv.get_tools` built the list by `append`, so mypy narrowed it from `self.search_tool`'s type and rejected the scrape-tool append with an `arg-type` error.
- Return directly from each branch instead; no type annotation needed.

## Test plan
- [x] `mypy src/strands_env` — no issues in 55 files
- [x] `ruff check src/` + `ruff format --check src/`
- [x] `pytest tests/unit/ -v` (140 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)