### PR TITLE
Fix: abort verification-failed samples in terminal-bench eval for retry

### DIFF
--- a/src/strands_env/environments/terminal_bench/reward.py
+++ b/src/strands_env/environments/terminal_bench/reward.py
@@ -40,10 +40,10 @@ class TerminalBenchReward(RewardFunction):
         """Run verification tests in Docker and return a binary reward."""
         try:
             reward = await self._run_verification()
-            return RewardResult(reward=reward)
+            return RewardResult(reward=reward, info={"status": "success"})
         except Exception as e:
             logger.exception("Verification failed due to %s: %s", type(e).__name__, str(e))
-            return RewardResult(reward=0.0, info={"error": str(e)})
+            return RewardResult(reward=0.0, info={"status": "error", "message": str(e)})
 
     async def _run_verification(self) -> float:
         """Upload tests, execute `test.sh`, download results, and parse reward."""
@@ -72,5 +72,4 @@ class TerminalBenchReward(RewardFunction):
         reward_path = trial_paths.reward_text_path
         if reward_path.exists() and reward_path.stat().st_size > 0:
             return 1.0 if float(reward_path.read_text().strip()) >= 1.0 else 0.0
-        logger.warning("No reward file at %s", reward_path)
-        return 0.0
+        raise RuntimeError(f"verification produced no reward file at {reward_path}")

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -96,6 +96,14 @@ class TerminalBenchEvaluator(Evaluator):
         )
         return sample
 
+    @override
+    def validate_sample(self, sample: EvalSample) -> bool:
+        """Abort samples where reward is missing or verification failed, so they are retried on resume."""
+        reward = sample.step_result.reward
+        if reward is None:
+            return False
+        return reward.info.get("status") != "error"
+
 
 @register_eval("terminal-bench-2")
 class TerminalBench2Evaluator(TerminalBenchEvaluator):


### PR DESCRIPTION
## Summary

- Align `TerminalBenchReward.info` schema with the rest of the codebase (`{"status": "success"|"error"}`).
- Add `TerminalBenchEvaluator.validate_sample` so verification-infra failures are marked aborted and retried on resume instead of being silently scored as `0.0` and counted in pass@k.

