### PR TITLE
fix(mcp_atlas): handle dict tool responses, catch tool errors, add default system prompt

### DIFF
--- a/src/strands_env/environments/mcp_atlas/env.py
+++ b/src/strands_env/environments/mcp_atlas/env.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import httpx
 from mcp.types import Tool as MCPToolDef
@@ -50,6 +51,8 @@ class MCPAtlasEnvironment(Environment):
     """
 
     DEFAULT_DOCKER_URL = "http://localhost:1984"
+
+    default_system_prompt_path = Path(__file__).parent / "system_prompt.md"
 
     def __init__(
         self,

--- a/src/strands_env/environments/mcp_atlas/system_prompt.md
+++ b/src/strands_env/environments/mcp_atlas/system_prompt.md
@@ -1,0 +1,1 @@
+You are a factual, tool-aware assistant connected to a variety of tools. Use the available tools to answer the user query. Do not ask the user for clarification; fully complete the task using the information provided in the prompt.

--- a/src/strands_env/environments/mcp_atlas/tool.py
+++ b/src/strands_env/environments/mcp_atlas/tool.py
@@ -29,5 +29,8 @@ class MCPAtlasTool(MCPToolAdapter):
         )
         if response.status_code != 200:  # upstream MCP server error
             return [ToolResultContent(text=response.text)], "error"
-        content = [ToolResultContent(text=str(item)) for item in response.json()]
+        content = [
+            ToolResultContent(text=item["text"] if isinstance(item, dict) and "text" in item else str(item))
+            for item in response.json()
+        ]
         return content, "success"

--- a/src/strands_env/tools/mcp_tool.py
+++ b/src/strands_env/tools/mcp_tool.py
@@ -89,6 +89,10 @@ class MCPToolAdapter(AgentTool):
     @override
     async def stream(self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any) -> ToolGenerator:
         """Stream a tool result back to the agent."""
-        content, status = await self.call_tool(self._mcp_tool.name, tool_use["input"])
+        try:
+            content, status = await self.call_tool(self._mcp_tool.name, tool_use["input"])
+        except Exception as e:
+            content = [ToolResultContent(text=f"Tool call failed: {type(e).__name__}: {e}")]
+            status = "error"
 
         yield ToolResultEvent(ToolResult(status=status, toolUseId=tool_use["toolUseId"], content=content))


### PR DESCRIPTION
## Summary

Three small improvements to MCP-Atlas robustness and ergonomics:

1. **`MCPAtlasTool`**: extract item["text"] when a tool response item is a dict, instead of falling through to str(item) which serialized the whole dict as "{'text': '...', 'type': '...'}".
2. **`MCPToolAdapter.stream`**: catch exceptions during `call_tool` and surface them as an error tool result instead of crashing the agent loop.
3. **`MCPAtlasEnvironment`**: add a built-in default system prompt via `default_system_prompt_path`.


## Tests

- `ruff` and `mypy`  pass on all changed files
- Verified in MCP-Atlas eval runs: dict-shaped tool responses are now correctly parsed; timeout tool calls now surface as error results and the eval continues
