### PR TITLE
docs: refresh evaluation/RL guides and add environments table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ strands-env eval aime-2024 \
 
 > **Tip:** For a non-agentic benchmark (no tool use), simply don't override `get_tools()` in your environment — the base class returns `[]` by default.
 
+## Built-in Environments
+
+Ready-to-use environments under `src/strands_env/environments/`. Each ships with its own README, system prompt, and `requirements.txt`.
+
+| Environment | Description |
+| --- | --- |
+| [`calculator`](src/strands_env/environments/calculator/README.md) | Simple environment with for math reasoning. |
+| [`code_sandbox`](src/strands_env/environments/code_sandbox/README.md) | Sandboxed Python / shell execution via AWS Bedrock AgentCore Code Interpreter. |
+| [`web_search`](src/strands_env/environments/web_search/README.md) | Pluggable search (Serper / Google CSE) + Jina-based page scraping with optional LLM summarization, enlightened by [OpenSeeker](https://github.com/rui-ye/OpenSeeker). |
+| [`terminal_bench`](src/strands_env/environments/terminal_bench/README.md) | Run [Terminal-Bench](https://www.tbench.ai/) tasks against a [Harbor](https://github.com/harbor-framework/harbor)-managed Docker/EKS container. |
+| [`swe_bench`](src/strands_env/environments/swe_bench/) | [SWE-bench](https://www.swebench.com/) task runner — thin subclass of `terminal_bench` with a SWE-bench-tuned system prompt. |
+| [`mcp_atlas`](src/strands_env/environments/mcp_atlas/README.md) | [MCP-Atlas](https://github.com/scaleapi/mcp-atlas) benchmark runner across 36 MCP servers. |
+
 ## Documentation
 
 - [Evaluation Guide](docs/evaluation.md) — CLI reference, hook files, custom evaluators

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -55,6 +55,9 @@ strands-env eval run --evaluator <dotted.module.path> --env <dotted.module.path>
 - `--keep-tokens` - Keep token-level observations in results
 - `--debug` - Enable debug logging
 
+**Distributed options:**
+- `--n-actors-per-node` - Ray actors per node for distributed eval. When set, an `EnvironmentActorPool` is created and rollouts are distributed across Ray actors. Omit for local single-process eval.
+
 ### Examples
 
 ```bash
@@ -80,19 +83,28 @@ strands-env eval run aime-2024 \
 strands-env eval run aime-2024 \
     --env examples.eval.simple_math.calculator_env \
     --env-config '{"max_tool_iters": 5}'
+
+# Distributed eval across Ray actors (e.g. 8 actors per node)
+strands-env eval run aime-2024 \
+    --env examples.eval.simple_math.calculator_env \
+    --base-url http://localhost:30000 \
+    --n-actors-per-node 8 \
+    --max-concurrency 30
 ```
 
 ## Hook Files
 
-Environment hook files define how environments are created for each evaluation sample. They must export a `create_env_factory` function.
+Environment hook files define how environments are created for each evaluation sample. They must export a `create_env_factory` function that takes a serializable `model_config` dict (plus environment-specific keyword args) and returns an async env factory. The `model_config` dict is passed to `build_model_factory` to construct the backend `ModelFactory`. This indirection keeps the hook serializable so it can be loaded inside Ray actors for distributed eval.
 
 ### Structure
 
 ```python
-from strands_env.core.models import ModelFactory
+from strands_env.core.models import build_model_factory
 
-def create_env_factory(model_factory: ModelFactory, **env_config):
+def create_env_factory(model_config: dict, **env_config):
     """Create an async environment factory."""
+    model_factory = build_model_factory(model_config)
+
     async def env_factory(action):
         return YourEnvironment(model_factory=model_factory, **env_config)
 
@@ -103,11 +115,12 @@ def create_env_factory(model_factory: ModelFactory, **env_config):
 
 ```python
 # examples/eval/simple_math/calculator_env.py
-from strands_env.core.models import ModelFactory
+from strands_env.core.models import build_model_factory
 from strands_env.environments.calculator import CalculatorEnv
 from strands_env.rewards import MathVerifyReward
 
-def create_env_factory(model_factory: ModelFactory, **env_config):
+def create_env_factory(model_config: dict, **env_config):
+    model_factory = build_model_factory(model_config)
     reward_fn = MathVerifyReward()
 
     async def env_factory(_action):
@@ -119,12 +132,13 @@ def create_env_factory(model_factory: ModelFactory, **env_config):
 ### Example: Code Sandbox Environment
 
 ```python
-# examples/eval/aime_code/code_sandbox_env.py
-from strands_env.core.models import ModelFactory
+# examples/eval/hmmt/code_sandbox_env.py
+from strands_env.core.models import build_model_factory
 from strands_env.environments.code_sandbox import CodeSandboxEnv
 from strands_env.rewards import MathVerifyReward
 
-def create_env_factory(model_factory: ModelFactory, **env_config):
+def create_env_factory(model_config: dict, **env_config):
+    model_factory = build_model_factory(model_config)
     reward_fn = MathVerifyReward()
 
     async def env_factory(_action):
@@ -205,7 +219,8 @@ Benchmarks are auto-discovered from the `benchmarks/` subdirectory. If a benchma
 ```python
 async def run_evaluation():
     evaluator = MyEvaluator(
-        env_factory=env_factory,
+        env_factory=env_factory,            # local: AsyncEnvFactory
+        # env_actor_pool=env_actor_pool,    # distributed: EnvironmentActorPool (mutually exclusive with env_factory)
         n_samples_per_prompt=8,
         max_concurrency=30,
         output_path="results.jsonl",
@@ -216,6 +231,18 @@ async def run_evaluation():
     results = await evaluator.run(actions)
     metrics = evaluator.compute_metrics(results)
     # {"pass@1": 0.75, "pass@8": 0.95, ...}
+```
+
+For distributed eval, build an `EnvironmentActorPool` with the dotted hook path and a serializable config dict, then pass it as `env_actor_pool` instead of `env_factory`:
+
+```python
+from strands_env.utils.ray import EnvironmentActorPool
+
+env_actor_pool = EnvironmentActorPool(
+    env_hook_path="examples.eval.simple_math.calculator_env.create_env_factory",
+    env_hook_config={"model_config": model_config.to_dict(), "max_tool_iters": 5},
+    n_actors_per_node=8,
+)
 ```
 
 ### Custom Metrics

--- a/docs/rl-training.md
+++ b/docs/rl-training.md
@@ -12,24 +12,31 @@ This guide covers integrating `strands-env` with RL training frameworks, specifi
 
 ## slime Integration
 
-Customize the `generate` and `reward_func` methods to replace single generation with agentic rollout:
+Customize the `generate` (and optionally `reward_func`) entry points to replace single-shot generation with an agentic rollout:
 
 ```python
-from strands_env.core import Action, TaskContext
-from strands_env.core.models import sglang_model_factory
+from slime.rollout.sglang_rollout import GenerateState
+from slime.utils.types import Sample
 from strands_sglang import get_client_from_slime_args
 
-async def generate(args, sample, sampling_params):
-    # Build model factory with cached client
-    factory = sglang_model_factory(
-        tokenizer=tokenizer,
-        client=get_client_from_slime_args(args),
+from strands_env.core import Action, TaskContext
+from strands_env.core.models import sglang_model_factory
+
+async def generate_and_rm(args, sample: Sample, sampling_params) -> Sample:
+    state = GenerateState(args)  # provides cached tokenizer + slime state
+
+    model_factory = sglang_model_factory(
+        tokenizer=state.tokenizer,
+        client=get_client_from_slime_args(args, timeout=300.0),
         sampling_params=sampling_params,
     )
 
-    # Create environment and run step
-    env = YourEnv(model_factory=factory, reward_fn=None)
-    action = Action(message=sample.prompt, task_context=TaskContext(ground_truth=sample.label))
+    env = YourEnv(model_factory=model_factory, reward_fn=YourRewardFunction())
+    prompt = sample.prompt if isinstance(sample.prompt, str) else sample.prompt[0]["content"]
+    action = Action(
+        message=prompt,
+        task_context=TaskContext(ground_truth=sample.label, conversation_history=[]),
+    )
     step_result = await env.step(action)
 
     # Extract TITO data for training
@@ -38,21 +45,36 @@ async def generate(args, sample, sampling_params):
     sample.loss_mask = token_obs.rollout_loss_mask
     sample.rollout_log_probs = token_obs.rollout_logprobs
     sample.response_length = len(token_obs.rollout_token_ids)
+    sample.response = state.tokenizer.decode(token_obs.rollout_token_ids, skip_special_tokens=False)
 
-    # Attach for reward computation
-    sample.action = action
-    sample.step_result = step_result
+    # Status + reward
+    sample.status = (
+        Sample.Status.COMPLETED
+        if step_result.termination_reason.value == "task_complete"
+        else Sample.Status.TRUNCATED
+    )
+    sample.reward = step_result.reward.reward
+    sample.step_result = step_result  # for custom rollout logging
+
+    await env.cleanup()
     return sample
+```
 
+If you want to compute the reward asynchronously (separate from the rollout), split the work into `generate` + `reward_func`:
+
+```python
 async def reward_func(args, sample, **kwargs):
     reward_fn = YourRewardFunction()
     reward_result = await reward_fn.compute(action=sample.action, step_result=sample.step_result)
     return reward_result.reward
 ```
 
+A complete worked example lives at `examples/slime/retool/generate_with_code_sandbox.py`.
+
 ## Key Points
 
 - **Connection pooling**: `get_client_from_slime_args(args)` provides `lru_cache`-backed connection pooling across rollouts for efficient GPU utilization
 - **Token observations**: `TokenObservation` contains token IDs and logprobs for on-policy training (SGLang backend only)
-- **Async rewards**: Reward is computed separately to allow async/batched reward computation
 - **Model factory pattern**: Each `step()` creates a fresh model instance for clean token tracking state
+- **Cleanup**: Call `await env.cleanup()` at the end of each rollout for envs that hold external resources (e.g. `CodeSandboxEnv`, `MCPEnvironment`, `TerminalBenchEnv`)
+- **Custom rollout logging**: Attach `step_result` to the sample and use `strands_env.utils.slime.RolloutLogger` (see the retool example) to log per-step metrics via slime's `--custom-rollout-log-function-path`


### PR DESCRIPTION
## Summary
- Realign `docs/evaluation.md` with the current code: `create_env_factory` now takes a serializable `model_config` dict (matches every hook under `examples/eval/` and the CLI call site), and the distributed Ray path (`--n-actors-per-node` / `EnvironmentActorPool`) is documented.
- Update `docs/rl-training.md` to mirror `examples/slime/retool/generate_with_code_sandbox.py` — uses `state.tokenizer` from `GenerateState`, adds the `await env.cleanup()` step, and points at `RolloutLogger` for custom slime rollout metrics.
- Add a "Built-in Environments" table to `README.md` linking each environment's README (calculator, code_sandbox, web_search, terminal_bench, swe_bench, mcp_atlas), with `mcp_atlas` correctly described as the MCP-Atlas benchmark runner.