### PR TITLE
docs: add agent_world_model env entry and extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Ready-to-use environments under `src/strands_env/environments/`. Each ships with
 | [`web_search`](src/strands_env/environments/web_search/README.md) | Pluggable search (Serper / Google CSE) + Jina-based page scraping with optional LLM summarization, enlightened by [OpenSeeker](https://github.com/rui-ye/OpenSeeker). |
 | [`terminal_bench`](src/strands_env/environments/terminal_bench/README.md) | Run [Terminal-Bench](https://www.tbench.ai/) tasks against a [Harbor](https://github.com/harbor-framework/harbor)-managed Docker/EKS container. |
 | [`swe_bench`](src/strands_env/environments/swe_bench/) | [SWE-bench](https://www.swebench.com/) task runner — thin subclass of `terminal_bench` with a SWE-bench-tuned system prompt. |
-| [`mcp_atlas`](src/strands_env/environments/mcp_atlas/README.md) | [MCP-Atlas](https://github.com/scaleapi/mcp-atlas) benchmark runner across 36 MCP servers. |
+| [`mcp_atlas`](src/strands_env/environments/mcp_atlas/README.md) | [MCP-Atlas](https://github.com/scaleapi/mcp-atlas) benchmark runner across 36 MCP servers with 500 tasks. |
+| [`agent_world_model`](src/strands_env/environments/agent_world_model/README.md) | [AgentWorldModel](https://github.com/scaleapi/agent-world-model) tasks with 1000 synthetic FastAPI + SQLite environments exposed as MCP tools. |
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ terminal-bench = [
     "awscli; python_version>='3.12'"
 ]
 ifeval = ["lm_eval[ifeval]>=0.4.11"]
+agent-world-model = ["agent-world-model==0.1.0"]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
## Summary
- Add `agent_world_model` row to the Built-in Environments table in README, linking to its README
- Tweak `mcp_atlas` row to mention 500 tasks alongside the 36 MCP servers
- Add `agent-world-model` optional dependency extra in `pyproject.toml` (pins `agent-world-model==0.1.0`)