### PR TITLE
fix: gate agent-world-model extra to Python >=3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ terminal-bench = [
     "awscli; python_version>='3.12'"
 ]
 ifeval = ["lm_eval[ifeval]>=0.4.11"]
-agent-world-model = ["agent-world-model==0.1.0"]
+agent-world-model = ["agent-world-model==0.1.0; python_version>='3.12'"]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
## Summary
- Restrict the `agent-world-model` optional dependency to Python 3.12+, matching the `terminal-bench` extra's pattern for packages that don't support older Python versions.

## Test plan
- [ ] `pip install -e ".[agent-world-model]"` succeeds on Python 3.12+
- [ ] `pip install -e ".[agent-world-model]"` no longer fails resolution on Python <3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)