### PR TITLE
chore(eval): include termination reason in per-sample log line

### DIFF
--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -182,8 +182,9 @@ class Evaluator:
             reward_str = f"{step_result.reward.reward:.2f}" if step_result.reward else "N/A"
             reward_info = step_result.reward.info if step_result.reward else {}
             logger.info(
-                "[%s]: reward=%s | label=%s | reward_info=%s | metrics=%s",
+                "[%s]: terminated=%s | reward=%s | label=%s | reward_info=%s | metrics=%s",
                 action.task_context.id,
+                step_result.termination_reason.value,
                 reward_str,
                 action.task_context.ground_truth,
                 reward_info,


### PR DESCRIPTION
## Summary
- Adds `terminated=<reason>` to the `Evaluator` per-sample log line so it's easy to spot failure modes (recursion errors, max-tool-calls, etc.) at a glance alongside reward/label/metrics.

## Test plan
- [x] Local eval run shows the new field in log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)