### PR TITLE
fix(eval): close harbor-aws aiohttp session at end of TerminalBench run

### DIFF
--- a/src/strands_env/environments/terminal_bench/_harbor_aws.py
+++ b/src/strands_env/environments/terminal_bench/_harbor_aws.py
@@ -79,3 +79,20 @@ async def ensure_harbor_aws_session() -> None:
                 sock_connect=30,
             ),
         )
+
+
+async def cleanup_harbor_aws_session() -> None:
+    """Close the shared aiohttp session installed by `ensure_harbor_aws_session`.
+
+    Call from a process-shutdown hook (e.g. an `Evaluator.run` `finally` clause) to
+    release the connector cleanly and avoid aiohttp's `Unclosed client session`
+    warning at GC. Idempotent; safe to call when no session was ever installed.
+    """
+    sess = AWSEnvironment._shared_aiohttp_session
+    if sess is None:
+        return
+    # harbor-aws annotates this attr as `object | None` since aiohttp is a soft dep there.
+    assert isinstance(sess, aiohttp.ClientSession)
+    AWSEnvironment._shared_aiohttp_session = None  # detach first so a re-entrant call is a no-op
+    if not sess.closed:
+        await sess.close()

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Iterable
 from pathlib import Path
 
 from harbor.models.task.task import Task
@@ -80,6 +81,14 @@ class TerminalBenchEvaluator(Evaluator):
         )
 
     @override
+    def validate_sample(self, sample: EvalSample) -> bool:
+        """Abort samples where reward is missing or verification failed, so they are retried on resume."""
+        reward = sample.step_result.reward
+        if reward is None:
+            return False
+        return reward.info.get("status") != "error"
+
+    @override
     async def evaluate_sample(self, action: Action) -> EvalSample:
         """Override to create sample-specific output directories for pass@k."""
         assert isinstance(action.task_context, TerminalBenchTaskContext)
@@ -98,12 +107,17 @@ class TerminalBenchEvaluator(Evaluator):
         return sample
 
     @override
-    def validate_sample(self, sample: EvalSample) -> bool:
-        """Abort samples where reward is missing or verification failed, so they are retried on resume."""
-        reward = sample.step_result.reward
-        if reward is None:
-            return False
-        return reward.info.get("status") != "error"
+    async def run(self, actions: Iterable[Action]) -> dict[str, list[EvalSample]]:
+        """Run evaluation on actions with `n_samples_per_prompt` each.
+
+        Closes the shared `harbor-aws` aiohttp session at exit if using the EKS backend.
+        """
+        try:
+            return await super().run(actions)
+        finally:
+            from strands_env.environments.terminal_bench._harbor_aws import cleanup_harbor_aws_session
+
+            await cleanup_harbor_aws_session()
 
 
 @register_eval("terminal-bench-2")


### PR DESCRIPTION
## Summary
- Add `cleanup_harbor_aws_session()` to `environments/terminal_bench/_harbor_aws.py` — closes the shared aiohttp `ClientSession` installed by `ensure_harbor_aws_session()`. Idempotent (detaches the class attribute first so re-entrant calls are no-ops).
- Override `run()` in `TerminalBenchEvaluator` to call it from a `finally` clause, so EKS-backed evals release the connector cleanly at the end of evaluation.
- Resolves the `asyncio - ERROR - Unclosed client session` / `Unclosed connector` warnings that previously fired at process shutdown.

## Test plan
- [x] Unit smoke: `ensure_harbor_aws_session` → `cleanup_harbor_aws_session` → re-install → cleanup; verified zero `Unclosed*` warnings via `warnings.catch_warnings`.
- [x] Idempotency: second `cleanup` call is a no-op.
- [x] Round-trip: re-installation after cleanup creates a fresh session (proves the cycle is restartable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)