### PR TITLE
feat(code_sandbox): make code interpreter session timeout configurable

### DIFF
--- a/src/strands_env/environments/code_sandbox/env.py
+++ b/src/strands_env/environments/code_sandbox/env.py
@@ -35,6 +35,7 @@ class CodeSandboxConfig(EnvironmentConfig, total=False):
     """Serializable configuration for `CodeSandboxEnv`."""
 
     mode: Literal["code", "terminal", "code_and_terminal"]
+    session_timeout_seconds: int
 
 
 class CodeSandboxEnv(Environment):
@@ -59,8 +60,14 @@ class CodeSandboxEnv(Environment):
         """Initialize a `CodeSandboxEnv` instance."""
         super().__init__(model_factory=model_factory, reward_fn=reward_fn, **config)  # type: ignore[misc]
         self.mode: str = self.config.get("mode", "code")
+        toolkit_kwargs: dict = {}
+        if "session_timeout_seconds" in self.config:
+            toolkit_kwargs["session_timeout_seconds"] = self.config["session_timeout_seconds"]
         self._toolkit = CodeInterpreterToolkit(
-            client=client or get_client(service_name="bedrock-agentcore"), session_name="strands-env", quotas=quotas
+            client=client or get_client(service_name="bedrock-agentcore"),
+            session_name="strands-env",
+            quotas=quotas,
+            **toolkit_kwargs,
         )
 
     @override

--- a/src/strands_env/tools/code_interpreter.py
+++ b/src/strands_env/tools/code_interpreter.py
@@ -80,12 +80,14 @@ class CodeInterpreterToolkit:
     """
 
     CODE_INTERPRETER_ID = "aws.codeinterpreter.v1"
+    DEFAULT_SESSION_TIMEOUT_SECONDS = 3600
 
     def __init__(
         self,
         client: BotoClient,
         session_name: str = "strands-env",
         quotas: CodeInterpreterQuotas | None = None,
+        session_timeout_seconds: int = DEFAULT_SESSION_TIMEOUT_SECONDS,
     ):
         """Initialize a `CodeInterpreterToolkit` instance.
 
@@ -95,12 +97,16 @@ class CodeInterpreterToolkit:
             quotas: Shared quotas for rate limiting, session concurrency, and thread pool.
                 Create one `CodeInterpreterQuotas` instance and pass it to all toolkit
                 instances to enforce account-wide limits.
+            session_timeout_seconds: Max session lifetime in seconds.
+                AgentCore tears the session down at the cap. Default matches the
+                AWS upper bound (3600). Lower values are useful for RL rollouts.
         """
         self.session_name = session_name
         self.client = client
         self.session_id: str | None = None
         self.quotas = quotas or CodeInterpreterQuotas()
         self._session_lock = asyncio.Lock()
+        self.session_timeout_seconds = session_timeout_seconds
 
     async def start_session(self) -> None:
         """Start a code interpreter session if not already started (async, thread-safe)."""
@@ -117,7 +123,7 @@ class CodeInterpreterToolkit:
                         self.client.start_code_interpreter_session,
                         codeInterpreterIdentifier=self.CODE_INTERPRETER_ID,
                         name=self.session_name,
-                        sessionTimeoutSeconds=3600,
+                        sessionTimeoutSeconds=self.session_timeout_seconds,
                     )
                 except Exception:
                     self.quotas.session_semaphore.release()

--- a/tests/unit/tools/test_code_interpreter.py
+++ b/tests/unit/tools/test_code_interpreter.py
@@ -169,3 +169,23 @@ class TestCodeInterpreterToolkit:
         # Toolkits 2,3 should start after ~200ms (when 0,1 release their slots)
         assert start_times[2] > 0.15
         assert start_times[3] > 0.15
+
+
+class TestSessionTimeout:
+    """Coverage for the configurable session timeout."""
+
+    async def test_session_timeout_seconds_passed_through(self):
+        """`session_timeout_seconds` is forwarded to start_code_interpreter_session."""
+        client = _mock_client()
+        toolkit = CodeInterpreterToolkit(client=client, session_timeout_seconds=600)
+        await toolkit.invoke("executeCode", {"code": "1", "language": "python"})
+        kwargs = client.start_code_interpreter_session.call_args.kwargs
+        assert kwargs["sessionTimeoutSeconds"] == 600
+
+    async def test_session_timeout_default_unchanged(self):
+        """Default keeps the historical 3600s value when caller doesn't override."""
+        client = _mock_client()
+        toolkit = CodeInterpreterToolkit(client=client)
+        await toolkit.invoke("executeCode", {"code": "1", "language": "python"})
+        kwargs = client.start_code_interpreter_session.call_args.kwargs
+        assert kwargs["sessionTimeoutSeconds"] == 3600


### PR DESCRIPTION
`CodeInterpreterToolkit` accepts `session_timeout_seconds` (default 3600, matching the AWS upper bound). Always defaulting to the upper bound will make RL rollouts bounded by the long tail. For some coding problems, the problem itself has a time limit so that we can catch TLE submissions. 


`CodeSandboxEnv` exposes the same knob through `CodeSandboxConfig` so callers can pass it via the env config dict.