### PR TITLE
feat(environment): record reward_fn compute time in observation metrics

### DIFF
--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import Any, ClassVar, TypeAlias
@@ -135,9 +136,15 @@ class Environment:
             messages=step_messages, tokens=token_obs, metrics=metrics, routed_experts=routed_experts
         )
         step_result = StepResult(observation=observation, termination_reason=termination_reason)
-        step_result.reward = (
-            (await self.reward_fn.compute(action=action, step_result=step_result)) if self.reward_fn else None
-        )
+        if self.reward_fn:
+            reward_t0 = time.perf_counter()
+            step_result.reward = await self.reward_fn.compute(action=action, step_result=step_result)
+            # Write to observation.metrics (the live dict on the model), not
+            # the local `metrics` — Pydantic v2 deep-copies dicts at model
+            # construction, so the local var is decoupled from the model after
+            # `Observation(...)` returns and downstream consumers only see
+            # observation.metrics.
+            observation.metrics["reward_compute_s"] = round(time.perf_counter() - reward_t0, 4)
         return step_result
 
     async def cleanup(self) -> None:

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -107,6 +107,13 @@ class TestStep:
 
         reward_fn.compute.assert_awaited_once()
         assert result.reward.reward == 1.0
+        # Regression: `reward_compute_s` must be observable via the StepResult's
+        # observation. Pydantic v2 deep-copies dicts at model construction, so
+        # writing to the local `metrics` var after `Observation(...)` returns
+        # is invisible to consumers — the timing must go through
+        # `observation.metrics` directly.
+        assert "reward_compute_s" in result.observation.metrics
+        assert result.observation.metrics["reward_compute_s"] >= 0.0
 
     @patch("strands_env.core.environment.Agent")
     async def test_step_with_dict_message(self, mock_agent_cls, env):


### PR DESCRIPTION
Record reward computation time for better observability. 

`Environment.step` now writes `reward_compute_s` to `observation.metrics` when a reward function runs, so trajectory traces can attribute time spent in the reward path separately from the rest of the step.

The metric must be written through `observation.metrics` rather than the local `metrics` dict — Pydantic v2 deep-copies dicts at model construction, so the local var is decoupled from the model after `Observation(...)` returns and downstream consumers only see `observation.metrics`. Regression test pinned in `test_environment.py`.