### PR TITLE
feat(types): classify connection-level failures as CONNECTION_ERROR

### DIFF
--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -174,6 +174,7 @@ class TerminationReason(str, Enum):
     MAX_TOOL_CALLS_REACHED = "max_tool_calls_reached"
     TIMEOUT = "timeout"
     RECURSION_DEPTH_EXCEEDED = "recursion_depth_exceeded"
+    CONNECTION_ERROR = "connection_error"
     UNCLASSIFIED_ERROR = "unclassified_error"
 
     @classmethod
@@ -182,6 +183,24 @@ class TerminationReason(str, Enum):
         exc = error
         while exc is not None:
             if "timeout" in type(exc).__name__.lower():
+                return True
+            exc = exc.__cause__
+        return False
+
+    @classmethod
+    def _is_connection_error(cls, error: BaseException | None) -> bool:
+        """Check if any exception in the cause chain is a connection-level failure.
+
+        Backend-agnostic name-match (mirrors `_is_timeout`'s pattern). Catches
+        builtin `ConnectionError` family plus aiohttp's `ClientConnectionError`,
+        `ServerDisconnectedError`, `ClientOSError`, and the typed
+        `SGLangConnectionError` wrapper — anything whose type name contains
+        `connection` or `disconnected` (case-insensitive).
+        """
+        exc = error
+        while exc is not None:
+            name = type(exc).__name__.lower()
+            if "connection" in name or "disconnected" in name:
                 return True
             exc = exc.__cause__
         return False
@@ -214,6 +233,8 @@ class TerminationReason(str, Enum):
                 reason = cls.RECURSION_DEPTH_EXCEEDED
             case e if cls._is_timeout(e):
                 reason = cls.TIMEOUT
+            case e if cls._is_connection_error(e):
+                reason = cls.CONNECTION_ERROR
             case _:
                 reason = cls.UNCLASSIFIED_ERROR
 

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -218,6 +218,46 @@ class TestTerminationReason:
         error.__cause__ = RecursionError("maximum recursion depth exceeded")
         assert TerminationReason.from_error(error) == TerminationReason.RECURSION_DEPTH_EXCEEDED
 
+    def test_connection_error_builtin(self):
+        error = EventLoopException(Exception())
+        error.__cause__ = ConnectionResetError("peer reset")
+        assert TerminationReason.from_error(error) == TerminationReason.CONNECTION_ERROR
+
+    def test_server_disconnected_by_name(self):
+        class ServerDisconnectedError(Exception):
+            pass
+
+        error = EventLoopException(Exception())
+        error.__cause__ = ServerDisconnectedError("Server disconnected")
+        assert TerminationReason.from_error(error) == TerminationReason.CONNECTION_ERROR
+
+    def test_sglang_connection_error_by_name(self):
+        class SGLangConnectionError(Exception):
+            pass
+
+        error = EventLoopException(Exception())
+        error.__cause__ = SGLangConnectionError("connection failed")
+        assert TerminationReason.from_error(error) == TerminationReason.CONNECTION_ERROR
+
+    def test_connection_error_in_cause_chain(self):
+        class ServerDisconnectedError(Exception):
+            pass
+
+        inner = ServerDisconnectedError()
+        outer = RuntimeError("wrapper")
+        outer.__cause__ = inner
+        assert TerminationReason.from_error(outer) == TerminationReason.CONNECTION_ERROR
+
+    def test_timeout_takes_precedence_over_connection(self):
+        # Both 'timeout' and 'connection' patterns in the chain — timeout wins
+        # because it's matched first in `from_error`.
+        class ServerTimeoutError(Exception):
+            pass
+
+        error = EventLoopException(Exception())
+        error.__cause__ = ServerTimeoutError()
+        assert TerminationReason.from_error(error) == TerminationReason.TIMEOUT
+
     def test_generic_error(self):
         error = EventLoopException(Exception())
         error.__cause__ = ValueError("something broke")


### PR DESCRIPTION
SGLangConnectionErrors were surfacing as Unclassified errors. Added a new TerminationReason to capture this. 

`TerminationReason.from_error` previously bucketed network failures into `UNCLASSIFIED_ERROR`, which collapsed real bugs and transient infra issues into the same triage bucket. Add a typed `CONNECTION_ERROR` reason and a `_is_connection_error` classifier mirroring `_is_timeout`'s name-pattern style — catches the builtin `ConnectionError` family plus aiohttp's `ClientConnectionError` / `ServerDisconnectedError` / `ClientOSError` and the typed `SGLangConnectionError` wrapper.

Timeout still wins precedence (matched first in `from_error`), so a `ServerTimeoutError` keeps reporting as `TIMEOUT`.