### PR TITLE
test(types): trim redundant CONNECTION_ERROR tests, shorten classifier docstring

### DIFF
--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -189,14 +189,7 @@ class TerminationReason(str, Enum):
 
     @classmethod
     def _is_connection_error(cls, error: BaseException | None) -> bool:
-        """Check if any exception in the cause chain is a connection-level failure.
-
-        Backend-agnostic name-match (mirrors `_is_timeout`'s pattern). Catches
-        builtin `ConnectionError` family plus aiohttp's `ClientConnectionError`,
-        `ServerDisconnectedError`, `ClientOSError`, and the typed
-        `SGLangConnectionError` wrapper — anything whose type name contains
-        `connection` or `disconnected` (case-insensitive).
-        """
+        """Check if any exception in the cause chain is a connection-level failure."""
         exc = error
         while exc is not None:
             name = type(exc).__name__.lower()

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -231,23 +231,6 @@ class TestTerminationReason:
         error.__cause__ = ServerDisconnectedError("Server disconnected")
         assert TerminationReason.from_error(error) == TerminationReason.CONNECTION_ERROR
 
-    def test_sglang_connection_error_by_name(self):
-        class SGLangConnectionError(Exception):
-            pass
-
-        error = EventLoopException(Exception())
-        error.__cause__ = SGLangConnectionError("connection failed")
-        assert TerminationReason.from_error(error) == TerminationReason.CONNECTION_ERROR
-
-    def test_connection_error_in_cause_chain(self):
-        class ServerDisconnectedError(Exception):
-            pass
-
-        inner = ServerDisconnectedError()
-        outer = RuntimeError("wrapper")
-        outer.__cause__ = inner
-        assert TerminationReason.from_error(outer) == TerminationReason.CONNECTION_ERROR
-
     def test_timeout_takes_precedence_over_connection(self):
         # Both 'timeout' and 'connection' patterns in the chain — timeout wins
         # because it's matched first in `from_error`.


### PR DESCRIPTION
## Summary

Follow-up to #119. Drops two unit tests that don't add coverage and tightens the `_is_connection_error` docstring.

- Removed `test_sglang_connection_error_by_name` — duplicate of `test_server_disconnected_by_name` (same name-match branch, different fake class name).
- Removed `test_connection_error_in_cause_chain` — redundant since the other three tests already exercise `__cause__` walking via `EventLoopException.__cause__ = ...`.
- Collapsed `_is_connection_error`'s docstring to a single line. The longer version named specific aiohttp/SGLang classes that will drift as those libraries evolve; behavior is "name contains `connection` or `disconnected`," which the code already shows.

Remaining three tests each cover a unique branch:
1. Builtin `ConnectionResetError` → `CONNECTION_ERROR` (isinstance path).
2. `ServerDisconnectedError` by name → `CONNECTION_ERROR` (substring path).
3. `ServerTimeoutError` → `TIMEOUT` (precedence ordering).

## Test plan

- [x] `pytest tests/unit/core/test_types.py -v` — 29 passed
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)