### PR TITLE
refactor(aws): align with boto3 naming, add resolve_region_name helper

### DIFF
--- a/examples/eval/browsecomp/chat_env.py
+++ b/examples/eval/browsecomp/chat_env.py
@@ -26,7 +26,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
         )
         judge_models.append(
             bedrock_model_factory(

--- a/examples/eval/browsecomp/web_search_env.py
+++ b/examples/eval/browsecomp/web_search_env.py
@@ -31,7 +31,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
         )
         judge_models.append(
             bedrock_model_factory(

--- a/examples/eval/frames/chat_env.py
+++ b/examples/eval/frames/chat_env.py
@@ -26,7 +26,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
         )
         judge_models.append(
             bedrock_model_factory(

--- a/examples/eval/hle_verified/chat_env.py
+++ b/examples/eval/hle_verified/chat_env.py
@@ -30,7 +30,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
-        boto_session = get_session(region="us-west-2", profile_name=profile_name)
+        boto_session = get_session(region_name="us-west-2", profile_name=profile_name)
         judge_models.append(
             bedrock_model_factory(
                 model_id=env_config.get("judge_model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0"),

--- a/examples/eval/mcp_atlas/env.py
+++ b/examples/eval/mcp_atlas/env.py
@@ -28,7 +28,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
-        boto_session = get_session(region="us-west-2", profile_name=profile_name)
+        boto_session = get_session(region_name="us-west-2", profile_name=profile_name)
         judge_models.append(
             bedrock_model_factory(
                 model_id=env_config.get("judge_model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0"),

--- a/examples/eval/sealqa/chat_env.py
+++ b/examples/eval/sealqa/chat_env.py
@@ -26,7 +26,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
         )
         judge_models.append(
             bedrock_model_factory(

--- a/examples/eval/simpleqa_verified/chat_env.py
+++ b/examples/eval/simpleqa_verified/chat_env.py
@@ -26,7 +26,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
         )
         judge_models.append(
             bedrock_model_factory(

--- a/src/strands_env/cli/eval.py
+++ b/src/strands_env/cli/eval.py
@@ -117,7 +117,7 @@ def list_cmd() -> None:
 @click.option("--base-url", type=str, default="http://localhost:30000", help="Base URL for SGLang server.")
 @click.option("--model-id", type=str, default=None, help="Model ID. Auto-detected for SGLang if not provided.")
 @click.option("--tokenizer-path", type=str, default=None, help="Tokenizer path for SGLang.")
-@click.option("--region", type=str, default=None, help="AWS region for Bedrock.")
+@click.option("--region-name", type=str, default=None, help="AWS region name for Bedrock.")
 @click.option("--profile-name", type=str, default=None, help="AWS profile name for Bedrock.")
 @click.option("--role-arn", type=str, default=None, help="AWS role ARN for Bedrock.")
 @click.option("--tool-parser", type=str, default=None, help="Tool parser name (e.g., 'hermes', 'qwen_xml').")
@@ -147,7 +147,7 @@ def run_cmd(
     base_url: str,
     model_id: str | None,
     tokenizer_path: str | None,
-    region: str | None,
+    region_name: str | None,
     profile_name: str | None,
     role_arn: str | None,
     tool_parser: str | None,
@@ -212,7 +212,7 @@ def run_cmd(
         tokenizer_path=tokenizer_path,
         tool_parser=tool_parser,
         max_connections=max_concurrency,
-        region_name=region or "us-west-2",
+        region_name=region_name,
         profile_name=profile_name,
         role_arn=role_arn,
         sampling_params=sampling_params,

--- a/src/strands_env/cli/eval.py
+++ b/src/strands_env/cli/eval.py
@@ -212,7 +212,7 @@ def run_cmd(
         tokenizer_path=tokenizer_path,
         tool_parser=tool_parser,
         max_connections=max_concurrency,
-        region=region or "us-west-2",
+        region_name=region or "us-west-2",
         profile_name=profile_name,
         role_arn=role_arn,
         sampling_params=sampling_params,

--- a/src/strands_env/core/models.py
+++ b/src/strands_env/core/models.py
@@ -300,7 +300,7 @@ class ModelConfig:
 
     # Bedrock / model identifier
     model_id: str | None = None
-    region: str = "us-west-2"
+    region_name: str | None = None
     profile_name: str | None = None
     role_arn: str | None = None
 
@@ -341,7 +341,7 @@ def build_model_factory(config: ModelConfig | dict[str, Any]) -> ModelFactory:
         case "bedrock":
             config.model_id = config.model_id or "us.anthropic.claude-sonnet-4-20250514-v1:0"
             boto_session = get_session(
-                region=config.region,
+                region_name=config.region_name,
                 profile_name=config.profile_name,
                 role_arn=config.role_arn,
             )

--- a/src/strands_env/utils/aws.py
+++ b/src/strands_env/utils/aws.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import TypeAlias
 
 import boto3
@@ -32,50 +31,47 @@ BotoClient: TypeAlias = BaseClient
 BotoClientConfig: TypeAlias = Config
 
 
-def _default_region() -> str:
-    """Honor standard AWS env vars; fall back to us-east-1 if neither is set."""
-    return os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
-
-
 def get_session(
-    region: str = "us-west-2",
+    region_name: str | None = None,
     profile_name: str | None = None,
     role_arn: str | None = None,
-    session_name: str = "strands-env",
+    role_session_name: str = "strands-env",
 ) -> boto3.Session:
     """Create a new boto3 session.
 
     Args:
-        region: AWS region name.
-        profile_name: Optional AWS profile name from ~/.aws/config.
+        region_name: AWS region name. If `None`, resolved by `boto3`.
+        profile_name: Optional AWS profile name from `~/.aws/config`.
         role_arn: Optional ARN of the IAM role to assume.
-        session_name: Session name for assumed role (only used if role_arn provided).
+        role_session_name: Session name for assumed role (only used if role_arn provided).
 
     Notes:
-        - Returns a **fresh** session every time — boto3 sessions are not thread-safe,
+        - Returns a **fresh** session every time — `boto3` sessions are not thread-safe,
           so they must not be shared across concurrent calls. Use `get_client` instead
           when you need a cached, thread-safe client.
         - If `role_arn` is provided, assumes the role using STS with auto-refreshing
           credentials via botocore's `RefreshableCredentials`.
     """
     if role_arn:
-        return create_assumed_role_session(role_arn, region, session_name)
+        return create_assumed_role_session(
+            role_arn=role_arn, role_session_name=role_session_name, region_name=region_name
+        )
     else:
-        logger.info("Creating boto3 session: region=%s, profile=%s", region, profile_name)
-        return boto3.Session(region_name=region, profile_name=profile_name)
+        logger.info("Creating boto3 session: region=%s, profile=%s", region_name, profile_name)
+        return boto3.Session(region_name=region_name, profile_name=profile_name)
 
 
-def create_assumed_role_session(role_arn: str, region: str, session_name: str) -> boto3.Session:
+def create_assumed_role_session(role_arn: str, role_session_name: str, region_name: str | None) -> boto3.Session:
     """Create a boto3 session with assumed role credentials."""
     from botocore.credentials import RefreshableCredentials
     from botocore.session import get_session as get_botocore_session
 
-    logger.info("Creating boto3 session with assumed role: role=%s, region=%s", role_arn, region)
+    logger.info("Creating boto3 session with assumed role: role=%s, region=%s", role_arn, region_name)
 
     def refresh() -> dict:
         logger.info("Refreshing STS credentials for assumed role: %s", role_arn)
-        sts = boto3.client("sts", region_name=region)
-        creds = sts.assume_role(RoleArn=role_arn, RoleSessionName=session_name)["Credentials"]
+        sts = boto3.client("sts", region_name=region_name)
+        creds = sts.assume_role(RoleArn=role_arn, RoleSessionName=role_session_name)["Credentials"]
         return {
             "access_key": creds["AccessKeyId"],
             "secret_key": creds["SecretAccessKey"],
@@ -91,48 +87,45 @@ def create_assumed_role_session(role_arn: str, region: str, session_name: str) -
 
     botocore_session = get_botocore_session()
     botocore_session._credentials = session_credentials
-    return boto3.Session(botocore_session=botocore_session, region_name=region)
+    return boto3.Session(botocore_session=botocore_session, region_name=region_name)
 
 
-@cache_by("service_name", "region", "profile_name", "role_arn", "session_name")
+@cache_by("service_name", "region_name", "profile_name", "role_arn", "role_session_name")
 def get_client(
     service_name: str,
-    region: str | None = None,
+    region_name: str | None = None,
     profile_name: str | None = None,
     role_arn: str | None = None,
-    session_name: str = "strands-env",
+    role_session_name: str = "strands-env",
     config: BotoClientConfig | None = None,
 ) -> BotoClient:
     """Get a cached boto3 client.
 
     Args:
         service_name: AWS service name (e.g. `"bedrock-agentcore"`, `"lambda"`, `"dynamodb"`).
-        region: AWS region name. If `None`, resolved from `AWS_REGION` /
-            `AWS_DEFAULT_REGION` env vars, falling back to `us-east-1`.
-        profile_name: Optional AWS profile name from ~/.aws/config.
+        region_name: AWS region name. If `None`, resolved by `boto3`.
+        profile_name: Optional AWS profile name from `~/.aws/config`.
         role_arn: Optional ARN of the IAM role to assume.
-        session_name: Session name for assumed role (only used if role_arn provided).
+        role_session_name: Session name for assumed role (only used if role_arn provided).
         config: Optional `botocore.config.Config` for client-level settings
             (e.g. `max_pool_connections`, `connect_timeout`, `read_timeout`, `retries`).
 
     Notes:
-        - Cached by `(service_name, region, profile_name, role_arn, session_name)`.
-          `config` is excluded from the cache key (not hashable). The cache key
-          uses the *resolved* region (after env-var fallback) so callers that
-          omit `region` still hit the same cache entry for the same env.
+        - Cached by `(service_name, region_name, profile_name, role_arn, role_session_name)`.
+          `config` is excluded from the cache key (not hashable).
         - Each client gets its own dedicated boto3 Session, avoiding the thread-safety
           issues of sharing a Session across clients. The client itself is thread-safe.
         - If `role_arn` is provided, the underlying Session uses `RefreshableCredentials`
           so the client auto-refreshes when credentials expire.
     """
-    if region is None:
-        region = _default_region()
     if role_arn:
-        session = create_assumed_role_session(role_arn, region, session_name)
+        session = create_assumed_role_session(
+            role_arn=role_arn, role_session_name=role_session_name, region_name=region_name
+        )
     else:
-        session = boto3.Session(region_name=region, profile_name=profile_name)
-    logger.info("Creating cached boto3 client: service=%s, region=%s", service_name, region)
-    return session.client(service_name, region_name=region, config=config)
+        session = boto3.Session(region_name=region_name, profile_name=profile_name)
+    logger.info("Creating cached boto3 client: service=%s, region=%s", service_name, region_name)
+    return session.client(service_name, region_name=region_name, config=config)
 
 
 def check_credentials(session: boto3.Session) -> bool:

--- a/src/strands_env/utils/aws.py
+++ b/src/strands_env/utils/aws.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TypeAlias
 
 import boto3
@@ -31,6 +32,26 @@ BotoClient: TypeAlias = BaseClient
 BotoClientConfig: TypeAlias = Config
 
 
+def resolve_region_name(region_name: str | None = None, profile_name: str | None = None) -> str:
+    """Resolve the AWS region name depending on the provided arguments.
+
+    Args:
+        region_name: AWS region name. If `None`, resolved in order of precedence:
+            - `AWS_REGION` env var
+            - `AWS_DEFAULT_REGION` env var
+            - profile region from `~/.aws/config`
+            - `us-east-1` fallback
+        profile_name: Optional AWS profile name from `~/.aws/config`.
+    """
+    return (
+        region_name
+        or os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or boto3.Session(profile_name=profile_name).region_name
+        or "us-east-1"
+    )
+
+
 def get_session(
     region_name: str | None = None,
     profile_name: str | None = None,
@@ -40,7 +61,7 @@ def get_session(
     """Create a new boto3 session.
 
     Args:
-        region_name: AWS region name. If `None`, resolved by `boto3`.
+        region_name: AWS region name. If `None`, resolved via `resolve_region_name`.
         profile_name: Optional AWS profile name from `~/.aws/config`.
         role_arn: Optional ARN of the IAM role to assume.
         role_session_name: Session name for assumed role (only used if role_arn provided).
@@ -52,6 +73,7 @@ def get_session(
         - If `role_arn` is provided, assumes the role using STS with auto-refreshing
           credentials via botocore's `RefreshableCredentials`.
     """
+    region_name = resolve_region_name(region_name=region_name, profile_name=profile_name)
     if role_arn:
         return create_assumed_role_session(
             role_arn=role_arn, role_session_name=role_session_name, region_name=region_name
@@ -61,7 +83,7 @@ def get_session(
     return session
 
 
-def create_assumed_role_session(role_arn: str, role_session_name: str, region_name: str | None) -> boto3.Session:
+def create_assumed_role_session(role_arn: str, role_session_name: str, region_name: str) -> boto3.Session:
     """Create a boto3 session with assumed role credentials."""
     from botocore.credentials import RefreshableCredentials
     from botocore.session import get_session as get_botocore_session
@@ -103,7 +125,7 @@ def get_client(
 
     Args:
         service_name: AWS service name (e.g. `"bedrock-agentcore"`, `"lambda"`, `"dynamodb"`).
-        region_name: AWS region name. If `None`, resolved by `boto3`.
+        region_name: AWS region name. If `None`, resolved via `resolve_region_name`.
         profile_name: Optional AWS profile name from `~/.aws/config`.
         role_arn: Optional ARN of the IAM role to assume.
         role_session_name: Session name for assumed role (only used if role_arn provided).
@@ -118,6 +140,7 @@ def get_client(
         - If `role_arn` is provided, the underlying Session uses `RefreshableCredentials`
           so the client auto-refreshes when credentials expire.
     """
+    region_name = resolve_region_name(region_name=region_name, profile_name=profile_name)
     if role_arn:
         session = create_assumed_role_session(
             role_arn=role_arn, role_session_name=role_session_name, region_name=region_name

--- a/src/strands_env/utils/aws.py
+++ b/src/strands_env/utils/aws.py
@@ -56,17 +56,15 @@ def get_session(
         return create_assumed_role_session(
             role_arn=role_arn, role_session_name=role_session_name, region_name=region_name
         )
-    else:
-        logger.info("Creating boto3 session: region=%s, profile=%s", region_name, profile_name)
-        return boto3.Session(region_name=region_name, profile_name=profile_name)
+    session = boto3.Session(region_name=region_name, profile_name=profile_name)
+    logger.info("Created boto3 session: region_name=%s, profile_name=%s", session.region_name, session.profile_name)
+    return session
 
 
 def create_assumed_role_session(role_arn: str, role_session_name: str, region_name: str | None) -> boto3.Session:
     """Create a boto3 session with assumed role credentials."""
     from botocore.credentials import RefreshableCredentials
     from botocore.session import get_session as get_botocore_session
-
-    logger.info("Creating boto3 session with assumed role: role=%s, region=%s", role_arn, region_name)
 
     def refresh() -> dict:
         logger.info("Refreshing STS credentials for assumed role: %s", role_arn)
@@ -87,7 +85,9 @@ def create_assumed_role_session(role_arn: str, role_session_name: str, region_na
 
     botocore_session = get_botocore_session()
     botocore_session._credentials = session_credentials
-    return boto3.Session(botocore_session=botocore_session, region_name=region_name)
+    session = boto3.Session(botocore_session=botocore_session, region_name=region_name)
+    logger.info("Created boto3 session with assumed role: role_arn=%s, region_name=%s", role_arn, session.region_name)
+    return session
 
 
 @cache_by("service_name", "region_name", "profile_name", "role_arn", "role_session_name")
@@ -124,8 +124,9 @@ def get_client(
         )
     else:
         session = boto3.Session(region_name=region_name, profile_name=profile_name)
-    logger.info("Creating cached boto3 client: service=%s, region=%s", service_name, region_name)
-    return session.client(service_name, region_name=region_name, config=config)
+    client = session.client(service_name, region_name=region_name, config=config)
+    logger.info("Created cached boto3 client: service_name=%s, region_name=%s", service_name, client.meta.region_name)
+    return client
 
 
 def check_credentials(session: boto3.Session) -> bool:

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -31,19 +31,19 @@ from strands_env.utils.decorators import cache_by, requires_env, with_timeout
 
 class TestGetSession:
     def test_returns_session(self):
-        session = get_session(region="us-west-2")
+        session = get_session(region_name="us-west-2")
         assert isinstance(session, boto3.Session)
         assert session.region_name == "us-west-2"
 
     def test_fresh_session_each_call(self):
-        session1 = get_session(region="us-east-1")
-        session2 = get_session(region="us-east-1")
+        session1 = get_session(region_name="us-east-1")
+        session2 = get_session(region_name="us-east-1")
         assert session1 is not session2
 
     @patch("strands_env.utils.aws.boto3.Session")
     def test_passes_profile(self, mock_session_cls):
         mock_session_cls.return_value = MagicMock()
-        get_session(region="us-east-1", profile_name="test-profile")
+        get_session(region_name="us-east-1", profile_name="test-profile")
         mock_session_cls.assert_called_once_with(region_name="us-east-1", profile_name="test-profile")
 
 
@@ -73,7 +73,7 @@ class TestGetSessionWithRoleAssumption:
         mock_get_session.return_value = mock_botocore_session
 
         role_arn = "arn:aws:iam::123456789:role/TestRole"
-        session = get_session(region="us-east-1", role_arn=role_arn)
+        session = get_session(region_name="us-east-1", role_arn=role_arn)
 
         mock_boto3_client.assert_called_with("sts", region_name="us-east-1")
         mock_sts.assume_role.assert_called_with(RoleArn=role_arn, RoleSessionName="strands-env")
@@ -118,7 +118,7 @@ class TestGetClient:
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
 
-        client = get_client("s3", region="us-east-1")
+        client = get_client("s3", region_name="us-east-1")
         assert client is mock_session.client.return_value
         mock_session.client.assert_called_once_with("s3", region_name="us-east-1", config=None)
 
@@ -127,8 +127,8 @@ class TestGetClient:
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
 
-        client1 = get_client("s3", region="us-east-1")
-        client2 = get_client("s3", region="us-east-1")
+        client1 = get_client("s3", region_name="us-east-1")
+        client2 = get_client("s3", region_name="us-east-1")
         assert client1 is client2
         assert mock_session_cls.call_count == 1
 
@@ -140,7 +140,7 @@ class TestGetClient:
         mock_session_cls.return_value = mock_session
 
         boto_config = Config(max_pool_connections=20, retries={"max_attempts": 3})
-        client = get_client("s3", region="us-east-1", config=boto_config)
+        client = get_client("s3", region_name="us-east-1", config=boto_config)
         assert client is mock_session.client.return_value
         mock_session.client.assert_called_once_with("s3", region_name="us-east-1", config=boto_config)
 

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -21,8 +21,49 @@ from unittest.mock import MagicMock, patch
 import boto3
 import pytest
 
-from strands_env.utils.aws import check_credentials, get_client, get_session
+from strands_env.utils.aws import check_credentials, get_client, get_session, resolve_region_name
 from strands_env.utils.decorators import cache_by, requires_env, with_timeout
+
+# ===========================================================================
+# AWS — resolve_region_name
+# ===========================================================================
+
+
+class TestResolveRegionName:
+    @pytest.fixture(autouse=True)
+    def _clear_aws_env(self, monkeypatch):
+        for var in ("AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_explicit_arg_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "ap-northeast-1")
+        assert resolve_region_name(region_name="ca-central-1") == "ca-central-1"
+
+    def test_aws_region_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        assert resolve_region_name() == "eu-west-1"
+
+    def test_aws_default_region_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "ap-northeast-1")
+        assert resolve_region_name() == "ap-northeast-1"
+
+    def test_aws_region_takes_precedence_over_default(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "ap-northeast-1")
+        assert resolve_region_name() == "eu-west-1"
+
+    @patch("strands_env.utils.aws.boto3.Session")
+    def test_falls_back_to_us_east_1_when_unresolved(self, mock_session_cls):
+        mock_session_cls.return_value.region_name = None
+        assert resolve_region_name() == "us-east-1"
+
+    @patch("strands_env.utils.aws.boto3.Session")
+    def test_uses_profile_region_when_envs_unset(self, mock_session_cls):
+        mock_session_cls.return_value.region_name = "sa-east-1"
+        assert resolve_region_name(profile_name="some-profile") == "sa-east-1"
+        mock_session_cls.assert_called_once_with(profile_name="some-profile")
+
 
 # ===========================================================================
 # AWS — get_session


### PR DESCRIPTION
## Summary

- Renames AWS-helper kwargs to match boto3 conventions: `region` → `region_name`, `session_name` → `role_session_name` across `get_session`, `get_client`, `create_assumed_role_session`, and `ModelConfig`. CLI flag `--region` → `--region-name`. All call sites in `examples/`, `cli/eval.py`, and `core/models.py` updated.
- Adds `resolve_region_name(region_name, profile_name)` with explicit arg → `AWS_REGION` → `AWS_DEFAULT_REGION` → profile region from `~/.aws/config` → `us-east-1` fallback. Plumbed into `get_session` and `get_client` so non-S3 clients (`dynamodb`, `bedrock-agentcore`, etc.) no longer raise `NoRegionError` when no region is configured. Restores the `AWS_REGION` env-var support that boto3 itself doesn't honor outside Lambda.
- Tightens `create_assumed_role_session(region_name: str)` since both internal callers now resolve before passing in.
- Moves `logger.info` lines in `get_session` / `create_assumed_role_session` / `get_client` to fire after the Session/Client is built, so the log shows the values boto3 actually resolved (`session.region_name`, `client.meta.region_name`) instead of the literal `None` the caller may have passed.
- Adds 6 unit tests for `resolve_region_name` covering each branch.

## Notes

- `cache_by` captures `region_name` *before* the function body runs, so `get_client("s3")` and `get_client("s3", region_name="us-east-1")` cache as separate entries even though they produce identical clients. Mild duplication for plain credentials; for `role_arn` callers this can mean duplicate `RefreshableCredentials` background refreshers if calls mix default-region and explicit-region forms. Not fixed here — would require a wrapper-around-cached structure.
- `ModelConfig.region_name` defaults to `None` (deferred to `resolve_region_name`); the CLI `--region-name` flag also defaults to `None`. Old `us-west-2` CLI default is removed.

## Test plan

- [x] Unit tests: `pytest tests/unit/` — 178 passed, 2 skipped
- [x] Ruff: `ruff check src/ tests/ examples/` clean
- [x] Ruff format check clean
- [x] Smoke: `get_client("dynamodb")` with no env vars set returns a client at `us-east-1` (previously raised `NoRegionError`)
- [x] Smoke: each `resolve_region_name` branch verified manually with env-var permutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)