### PR TITLE
refactor(environment): rename reward_compute_s -> reward_latency_s

### DIFF
--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -139,12 +139,7 @@ class Environment:
         if self.reward_fn:
             reward_t0 = time.perf_counter()
             step_result.reward = await self.reward_fn.compute(action=action, step_result=step_result)
-            # Write to observation.metrics (the live dict on the model), not
-            # the local `metrics` — Pydantic v2 deep-copies dicts at model
-            # construction, so the local var is decoupled from the model after
-            # `Observation(...)` returns and downstream consumers only see
-            # observation.metrics.
-            observation.metrics["reward_compute_s"] = round(time.perf_counter() - reward_t0, 4)
+            observation.metrics["reward_latency_s"] = round(time.perf_counter() - reward_t0, 4)
         return step_result
 
     async def cleanup(self) -> None:

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -107,13 +107,11 @@ class TestStep:
 
         reward_fn.compute.assert_awaited_once()
         assert result.reward.reward == 1.0
-        # Regression: `reward_compute_s` must be observable via the StepResult's
-        # observation. Pydantic v2 deep-copies dicts at model construction, so
-        # writing to the local `metrics` var after `Observation(...)` returns
-        # is invisible to consumers — the timing must go through
-        # `observation.metrics` directly.
-        assert "reward_compute_s" in result.observation.metrics
-        assert result.observation.metrics["reward_compute_s"] >= 0.0
+        # Regression: timing must be written via `observation.metrics`, not the
+        # local `metrics` dict — Pydantic v2 rebuilds the dict at validation, so
+        # the local var is decoupled from the model after `Observation(...)`.
+        assert "reward_latency_s" in result.observation.metrics
+        assert result.observation.metrics["reward_latency_s"] >= 0.0
 
     @patch("strands_env.core.environment.Agent")
     async def test_step_with_dict_message(self, mock_agent_cls, env):


### PR DESCRIPTION
## Summary
- Rename `reward_compute_s` to `reward_latency_s` so the metric matches the existing `*_latency_s` convention (`model_latency_s`, per-tool `latency_s`).
- Drop the 5-line explanatory block in `environment.py` and keep a single concise note in the regression test.

Follow-up to #118 (just merged). Since #118 only landed today, no downstream consumers should be keying on the old name yet.

## Test plan
- [x] `pytest tests/unit/core/test_environment.py::TestStep::test_step_with_reward_fn -v` passes
- [x] Full unit suite passes (178 passed, 2 skipped)
- [x] `ruff check` / `ruff format --check` clean
- [x] mypy: no new errors introduced (pre-existing errors in `aws.py` / `code_interpreter.py` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)