### PR TITLE
refactor(code_sandbox): simplify session_timeout_seconds plumbing

### DIFF
--- a/src/strands_env/environments/code_sandbox/env.py
+++ b/src/strands_env/environments/code_sandbox/env.py
@@ -60,14 +60,13 @@ class CodeSandboxEnv(Environment):
         """Initialize a `CodeSandboxEnv` instance."""
         super().__init__(model_factory=model_factory, reward_fn=reward_fn, **config)  # type: ignore[misc]
         self.mode: str = self.config.get("mode", "code")
-        toolkit_kwargs: dict = {}
-        if "session_timeout_seconds" in self.config:
-            toolkit_kwargs["session_timeout_seconds"] = self.config["session_timeout_seconds"]
         self._toolkit = CodeInterpreterToolkit(
             client=client or get_client(service_name="bedrock-agentcore"),
             session_name="strands-env",
+            session_timeout_seconds=self.config.get(
+                "session_timeout_seconds", CodeInterpreterToolkit.DEFAULT_SESSION_TIMEOUT_SECONDS
+            ),
             quotas=quotas,
-            **toolkit_kwargs,
         )
 
     @override

--- a/src/strands_env/tools/code_interpreter.py
+++ b/src/strands_env/tools/code_interpreter.py
@@ -86,27 +86,25 @@ class CodeInterpreterToolkit:
         self,
         client: BotoClient,
         session_name: str = "strands-env",
-        quotas: CodeInterpreterQuotas | None = None,
         session_timeout_seconds: int = DEFAULT_SESSION_TIMEOUT_SECONDS,
+        quotas: CodeInterpreterQuotas | None = None,
     ):
         """Initialize a `CodeInterpreterToolkit` instance.
 
         Args:
             client: boto3 client for bedrock-agentcore service.
             session_name: Name for the code interpreter session.
+            session_timeout_seconds: Max session lifetime in seconds.
             quotas: Shared quotas for rate limiting, session concurrency, and thread pool.
                 Create one `CodeInterpreterQuotas` instance and pass it to all toolkit
                 instances to enforce account-wide limits.
-            session_timeout_seconds: Max session lifetime in seconds.
-                AgentCore tears the session down at the cap. Default matches the
-                AWS upper bound (3600). Lower values are useful for RL rollouts.
         """
-        self.session_name = session_name
         self.client = client
         self.session_id: str | None = None
+        self.session_name = session_name
+        self.session_timeout_seconds = session_timeout_seconds
         self.quotas = quotas or CodeInterpreterQuotas()
         self._session_lock = asyncio.Lock()
-        self.session_timeout_seconds = session_timeout_seconds
 
     async def start_session(self) -> None:
         """Start a code interpreter session if not already started (async, thread-safe)."""


### PR DESCRIPTION
## Summary
- `CodeSandboxEnv` now passes `session_timeout_seconds` directly with `CodeInterpreterToolkit.DEFAULT_SESSION_TIMEOUT_SECONDS` as the fallback, replacing the conditional `toolkit_kwargs` dict pattern from #116.
- Group `session_*` params/attributes together in `CodeInterpreterToolkit.__init__` so all session-related fields read in one place.

## Test plan
- [x] `ruff check src/` and `ruff format --check src/` pass
- [x] `pytest tests/unit/` — 180 passed, 2 skipped (Kimi tests, unrelated)
- [x] Existing `TestSessionTimeout` cases (`test_session_timeout_seconds_passed_through`, `test_session_timeout_default_unchanged`) still pass against the reordered kwargs

🤖 Generated with [Claude Code](https://claude.com/claude-code)