### PR TITLE
refactor: adopt strands-sglang Rollout, retire TokenObservation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-sglang>=0.3.7",
+    "strands-sglang>=0.4.1",
     "strands-agents-tools>=0.2.0",
     "openai",
     "datasets",

--- a/src/strands_env/cli/eval.py
+++ b/src/strands_env/cli/eval.py
@@ -132,7 +132,7 @@ def list_cmd() -> None:
 @click.option("--output", "-o", type=click.Path(path_type=Path), default=None, help="Output directory.")
 @click.option("--max-samples", type=int, default=None, help="Maximum dataset samples to evaluate.")
 @click.option("--save-interval", type=int, default=10, help="Save results every N samples.")
-@click.option("--keep-tokens", is_flag=True, default=False, help="Keep token-level observations in results.")
+@click.option("--keep-rollout", is_flag=True, default=False, help="Keep the token-level rollout in results.")
 # Distributed
 @click.option("--n-actors-per-node", type=int, default=None, help="Ray actors per node for distributed eval.")
 # Debug
@@ -162,7 +162,7 @@ def run_cmd(
     max_samples: int | None,
     output: Path,
     save_interval: int,
-    keep_tokens: bool,
+    keep_rollout: bool,
     # Distributed
     n_actors_per_node: int | None,
     # Misc
@@ -248,7 +248,7 @@ def run_cmd(
         n_samples_per_prompt=n_samples_per_prompt,
         output_path=output_dir / "results.jsonl",
         save_interval=save_interval,
-        keep_tokens=keep_tokens,
+        keep_rollout=keep_rollout,
         env_actor_pool=env_actor_pool,
     )
     actions = list(evaluator.load_dataset())[:max_samples]

--- a/src/strands_env/core/__init__.py
+++ b/src/strands_env/core/__init__.py
@@ -24,7 +24,6 @@ from .types import (
     StepResult,
     TaskContext,
     TerminationReason,
-    TokenObservation,
 )
 
 __all__ = [
@@ -39,5 +38,4 @@ __all__ = [
     "StepResult",
     "TaskContext",
     "TerminationReason",
-    "TokenObservation",
 ]

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -26,7 +26,7 @@ from strands import Agent
 from strands.agent.conversation_manager import ConversationManager, NullConversationManager
 from strands.handlers.callback_handler import PrintingCallbackHandler
 from strands.telemetry.metrics import EventLoopMetrics
-from strands_sglang import TokenManager, ToolLimiter
+from strands_sglang import ToolLimiter
 from typing_extensions import TypedDict, Unpack
 
 from .models import ModelFactory
@@ -36,7 +36,6 @@ from .types import (
     RewardFunction,
     StepResult,
     TerminationReason,
-    TokenObservation,
 )
 
 logger = logging.getLogger(__name__)
@@ -97,6 +96,7 @@ class Environment:
 
     async def step(self, action: Action) -> StepResult:
         """Run one agent episode and return observation + reward + termination."""
+        # 1. Build inputs and the agent.
         conversation_history = action.task_context.conversation_history
         tool_limiter = ToolLimiter(
             max_tool_iters=self.max_tool_iters,
@@ -113,6 +113,7 @@ class Environment:
             conversation_manager=self.get_conversation_manager(),
             callback_handler=PrintingCallbackHandler() if self.verbose else None,
         )
+        # 2. Run the agent loop.
         error = None
         try:
             message = action.message if isinstance(action.message, str) else action.message["content"]
@@ -121,8 +122,9 @@ class Environment:
             error = e
         termination_reason = TerminationReason.from_error(error)
 
+        # 3. Build the observation.
         step_messages = list(agent.messages)[len(conversation_history) :]
-        token_obs = TokenObservation.from_token_manager(getattr(agent.model, "token_manager", TokenManager()))
+        rollout = getattr(agent.model, "rollout", None)
         tool_parse_errors = getattr(agent.model, "tool_parse_errors", None)
         metrics = {
             "message_count": len(step_messages),
@@ -131,15 +133,15 @@ class Environment:
             "cancelled_tool_calls": tool_limiter.cancelled_tool_call_count,
             **self.compute_metrics(agent.event_loop_metrics, tool_parse_errors=tool_parse_errors),
         }
-        routed_experts = getattr(agent.model, "routed_experts", None)
-        observation = Observation(
-            messages=step_messages, tokens=token_obs, metrics=metrics, routed_experts=routed_experts
-        )
+        observation = Observation(messages=step_messages, rollout=rollout, metrics=metrics)
         step_result = StepResult(observation=observation, termination_reason=termination_reason)
+
+        # 4. Compute and time the reward (if any).
         if self.reward_fn:
             reward_t0 = time.perf_counter()
             step_result.reward = await self.reward_fn.compute(action=action, step_result=step_result)
             observation.metrics["reward_latency_s"] = round(time.perf_counter() - reward_t0, 4)
+
         return step_result
 
     async def cleanup(self) -> None:

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -25,7 +25,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 from strands.types.content import Message, Messages
 from strands.types.exceptions import ContextWindowOverflowException, EventLoopException, MaxTokensReachedException
-from strands_sglang import MaxToolCallsReachedError, MaxToolIterationsReachedError, TokenManager
+from strands_sglang import MaxToolCallsReachedError, MaxToolIterationsReachedError, Rollout
 
 logger = logging.getLogger(__name__)
 
@@ -59,70 +59,19 @@ class Action(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class TokenObservation(BaseModel):
-    """Token-level observation for Token-in/Token-out (TITO) training.
-
-    `prompt_length` splits the flat `token_ids` list into initial-prompt vs. rollout.
-    `loss_mask` and `logprobs` cover all tokens (use rollout slices for training).
-    """
-
-    token_ids: list[int] = Field(default_factory=list)
-    prompt_length: int = Field(default=0)
-    loss_mask: list[int] = Field(default_factory=list)
-    logprobs: list[float | None] = Field(default_factory=list)
-
-    @property
-    def rollout_token_ids(self) -> list[int]:
-        """Return token IDs for the rollout (after the initial prompt)."""
-        return self.token_ids[self.prompt_length :]
-
-    @property
-    def rollout_logprobs(self) -> list[float | None]:
-        """Return logprobs for the rollout tokens."""
-        return self.logprobs[self.prompt_length :]
-
-    @property
-    def rollout_loss_mask(self) -> list[int]:
-        """Return loss mask for the rollout tokens."""
-        return self.loss_mask[self.prompt_length :]
-
-    @property
-    def initial_prompt_token_ids(self) -> list[int]:
-        """Return token IDs for the initial prompt."""
-        return self.token_ids[: self.prompt_length]
-
-    @classmethod
-    def from_token_manager(cls, token_manager: TokenManager) -> TokenObservation | None:
-        """Create from strands-sglang's `TokenManager`; returns None if empty."""
-        if len(token_manager) == 0:
-            return None
-        return cls(
-            token_ids=token_manager.token_ids,
-            prompt_length=len(token_manager.initial_prompt),
-            loss_mask=token_manager.loss_mask,
-            logprobs=token_manager.logprobs,
-        )
-
-
 class Observation(BaseModel):
     """Step observation: messages produced, optional token data, and metrics."""
 
     messages: Messages = Field(default_factory=list)
-    tokens: TokenObservation | None = None
+    rollout: Rollout | None = None
     metrics: dict[str, Any] = Field(default_factory=dict)
-    routed_experts: str | None = None
 
     @property
     def final_response(self) -> str | None:
         """Return text from the last assistant message, or None."""
-        return self.get_final_response(self.messages)
-
-    @staticmethod
-    def get_final_response(messages: Messages) -> str | None:
-        """Extract text from the last assistant message, or None."""
-        if not messages or messages[-1].get("role") != "assistant":
+        if not self.messages or self.messages[-1].get("role") != "assistant":
             return None
-        content = messages[-1].get("content", [])
+        content = self.messages[-1].get("content", [])
         # Take the last text block — the final textual output.
         text = next(
             (block["text"] for block in reversed(content) if isinstance(block, dict) and "text" in block),

--- a/src/strands_env/environments/agent_world_model/reward.py
+++ b/src/strands_env/environments/agent_world_model/reward.py
@@ -26,7 +26,7 @@ import sqlite3
 import traceback
 from typing import Any
 
-from strands_env.core.types import Action, Observation, RewardFunction, RewardResult, StepResult
+from strands_env.core.types import Action, RewardFunction, RewardResult, StepResult
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class AgentWorldModelRewardFunction(RewardFunction):
     async def compute(self, action: Action, step_result: StepResult) -> RewardResult:
         """Run verification code against the agent's final response."""
         ctx: Any = action.task_context
-        final_answer = Observation.get_final_response(step_result.observation.messages) or ""
+        final_answer = step_result.observation.final_response or ""
 
         try:
             result = await asyncio.to_thread(

--- a/src/strands_env/environments/mcp_atlas/reward.py
+++ b/src/strands_env/environments/mcp_atlas/reward.py
@@ -33,7 +33,7 @@ import logging
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
-from strands_env.core.types import Action, Observation, RewardResult, StepResult
+from strands_env.core.types import Action, RewardResult, StepResult
 from strands_env.rewards.llm_judge_reward import LLMJudgeReward
 
 logger = logging.getLogger(__name__)
@@ -123,7 +123,7 @@ class MCPAtlasRewardFunction(LLMJudgeReward[ClaimJudgment]):
         if not claims:
             return RewardResult(reward=self.default_reward, info={"reason": "no_claims"})
 
-        self._response = Observation.get_final_response(step_result.observation.messages) or ""
+        self._response = step_result.observation.final_response or ""
 
         claim_results = []
         for claim in claims:

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -67,7 +67,7 @@ class Evaluator:
         n_samples_per_prompt: int = 1,
         output_path: Path | str | None = None,
         save_interval: int = 10,
-        keep_tokens: bool = False,
+        keep_rollout: bool = False,
         env_actor_pool: EnvironmentActorPool | None = None,
     ):
         """Initialize an `Evaluator` instance.
@@ -79,7 +79,7 @@ class Evaluator:
             n_samples_per_prompt: Number of samples per prompt (for pass@k, set to max(k_values)).
             output_path: Path to JSONL file for saving results. Enables resume.
             save_interval: Flush results to disk every N completed samples.
-            keep_tokens: Keep token-level observation in results (only valid for `SGLangModel` backends).
+            keep_rollout: Keep the token-level rollout in results (only valid for `SGLangModel` backends).
             env_actor_pool: Optional Ray actor pool for distributed evaluation.
         """
         if env_factory is None and env_actor_pool is None:
@@ -92,7 +92,7 @@ class Evaluator:
         self.n_samples_per_prompt = n_samples_per_prompt
         self.output_path = Path(output_path)
         self.save_interval = save_interval
-        self.keep_tokens = keep_tokens
+        self.keep_rollout = keep_rollout
 
         # Runtime state
         self.results: dict[str, list[EvalSample]] = defaultdict(list)
@@ -175,9 +175,9 @@ class Evaluator:
                     step_result = await env.step(action)
                 finally:
                     await env.cleanup()
-            # Clean up token-level observation if not needed to reduce verbosity
-            if not self.keep_tokens:
-                step_result.observation.tokens = None
+            # Clean up the token-level rollout if not needed to reduce verbosity
+            if not self.keep_rollout:
+                step_result.observation.rollout = None
             # Runtime logging for debugging
             reward_str = f"{step_result.reward.reward:.2f}" if step_result.reward else "N/A"
             reward_info = step_result.reward.info if step_result.reward else {}

--- a/src/strands_env/utils/sglang.py
+++ b/src/strands_env/utils/sglang.py
@@ -34,10 +34,11 @@ def check_server_health(base_url: str, timeout: float = 5.0) -> None:
 
 
 def get_model_id(base_url: str, timeout: float = 5.0) -> str:
-    """Get the model ID from the SGLang server via ``/v1/models``."""
-    response = httpx.get(f"{base_url}/v1/models", timeout=timeout)
+    """Get the model's HF identifier from the SGLang server via `/get_model_info`."""
+    response = httpx.get(f"{base_url}/get_model_info", timeout=timeout)
     response.raise_for_status()
-    models = response.json()["data"]
-    if not models:
-        raise RuntimeError(f"No models found at {base_url}/v1/models")
-    return str(models[0]["id"])
+    info = response.json()
+    model_id = info.get("tokenizer_path") or info.get("model_path")
+    if not model_id:
+        raise RuntimeError(f"No tokenizer_path/model_path at {base_url}/get_model_info")
+    return str(model_id)

--- a/src/strands_env/utils/slime.py
+++ b/src/strands_env/utils/slime.py
@@ -177,17 +177,18 @@ class RolloutLogger:
         for s in random.sample(samples, k=n_saved):
             step_result: StepResult = s.step_result
             obs = step_result.observation
-            token_obs = obs.tokens
-            if not token_obs:
-                logger.warning("[weave] rollout %d missing `token_obs`", rollout_id)
+            rollout = obs.rollout
+            if not rollout:
+                logger.warning("[weave] rollout %d missing token rollout", rollout_id)
                 continue
 
+            prompt_len = rollout.initial_prompt_length
             rows.append(
                 {
                     "rollout_id": rollout_id,
                     "step": step,
-                    "prompt": tokenizer.decode(token_obs.initial_prompt_token_ids, skip_special_tokens=False),
-                    "response": tokenizer.decode(token_obs.rollout_token_ids, skip_special_tokens=False),
+                    "prompt": tokenizer.decode(rollout.token_ids[:prompt_len], skip_special_tokens=False),
+                    "response": tokenizer.decode(rollout.token_ids[prompt_len:], skip_special_tokens=False),
                     "termination_reason": step_result.termination_reason.value,
                     "reward": step_result.reward.reward if step_result.reward else None,
                     "reward_info": step_result.reward.info if step_result.reward else None,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,15 +44,16 @@ def assert_successful_step(result: StepResult) -> None:
     assert result.observation.final_response
 
 
-def assert_token_observation(result: StepResult) -> None:
-    """Assert that token-level observation has valid structure."""
-    tokens = result.observation.tokens
-    assert tokens is not None
-    assert tokens.prompt_length > 0
-    assert len(tokens.rollout_token_ids) > 0
-    assert len(tokens.loss_mask) == len(tokens.token_ids)
-    assert len(tokens.logprobs) == len(tokens.token_ids)
-    assert any(lp is not None for lp in tokens.rollout_logprobs)
+def assert_rollout(result: StepResult) -> None:
+    """Assert that the token-level rollout has valid structure."""
+    rollout = result.observation.rollout
+    assert rollout is not None
+    prompt_len = rollout.initial_prompt_length
+    assert prompt_len > 0
+    assert len(rollout.token_ids) > prompt_len
+    assert len(rollout.loss_mask) == len(rollout.token_ids)
+    assert len(rollout.logprobs) == len(rollout.token_ids)
+    assert any(lp is not None for lp in rollout.logprobs[prompt_len:])
 
 
 def assert_token_usage(result: StepResult) -> None:

--- a/tests/integration/test_calculator_env.py
+++ b/tests/integration/test_calculator_env.py
@@ -24,7 +24,7 @@ from strands_env.core.types import Action, TaskContext, TerminationReason
 from strands_env.environments.calculator import CalculatorEnv
 from strands_env.rewards.math_verify_reward import MathVerifyReward
 
-from .conftest import assert_successful_step, assert_token_observation, assert_token_usage
+from .conftest import assert_rollout, assert_successful_step, assert_token_usage
 
 MATH_SYSTEM_PROMPT = "You are a math assistant. Use the calculator tool to solve problems. Be concise."
 
@@ -43,7 +43,7 @@ class TestCalculatorEnv:
         result = await env.step(Action(message="What is 17 * 23?"))
 
         assert_successful_step(result)
-        assert_token_observation(result)
+        assert_rollout(result)
         assert_token_usage(result)
 
         # Per-tool breakdown for calculator

--- a/tests/integration/test_code_sandbox.py
+++ b/tests/integration/test_code_sandbox.py
@@ -25,7 +25,7 @@ from strands_env.core.types import Action, RewardResult, StepResult, TaskContext
 from strands_env.environments.code_sandbox import CodeSandboxEnv
 from strands_env.utils.aws import check_credentials, get_client, get_session
 
-from .conftest import assert_successful_step, assert_token_observation, assert_token_usage
+from .conftest import assert_rollout, assert_successful_step, assert_token_usage
 
 FORCE_TOOL_PROMPT = (
     "You are a coding assistant. Always use the execute_code tool. "
@@ -67,7 +67,7 @@ class TestCodeSandboxEnv:
         result = await code_env.step(Action(message="Use code to compute 2 ** 10 and tell me the result."))
 
         assert_successful_step(result)
-        assert_token_observation(result)
+        assert_rollout(result)
         assert_token_usage(result)
 
         assert result.observation.metrics["per_tool_metrics"]["execute_code"]["calls"] >= 1

--- a/tests/integration/test_terminal_bench.py
+++ b/tests/integration/test_terminal_bench.py
@@ -30,7 +30,7 @@ pytest.importorskip("harbor", reason="harbor>=0.1.43 required for terminal_bench
 from strands_env.core.types import Action, TaskContext, TerminationReason
 from strands_env.environments.terminal_bench import TerminalBenchEnv
 
-from .conftest import assert_successful_step, assert_token_observation, assert_token_usage
+from .conftest import assert_rollout, assert_successful_step, assert_token_usage
 
 FORCE_TOOL_PROMPT = (
     "You are a terminal assistant. Always use execute_command. "
@@ -101,7 +101,7 @@ class TestTerminalBench:
         result = await terminal_bench_env.step(Action(message="Run 'echo hello world' in the terminal."))
 
         assert_successful_step(result)
-        assert_token_observation(result)
+        assert_rollout(result)
         assert_token_usage(result)
         assert result.observation.metrics["per_tool_metrics"]["execute_command"]["calls"] >= 1
 

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -17,7 +17,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from strands_sglang import TokenManager
+from strands_sglang import Rollout
 
 from strands_env.core.environment import Environment
 
@@ -51,8 +51,7 @@ def mock_agent(messages: list | None = None, event_loop_metrics: MagicMock | Non
     agent_instance = MagicMock()
     agent_instance.invoke_async = AsyncMock()
     agent_instance.messages = messages if messages is not None else []
-    agent_instance.model.token_manager = TokenManager()
-    agent_instance.model.routed_experts = None
+    agent_instance.model.rollout = Rollout()
     agent_instance.event_loop_metrics = event_loop_metrics or mock_event_loop_metrics()
     return agent_instance
 
@@ -65,7 +64,7 @@ def mock_agent(messages: list | None = None, event_loop_metrics: MagicMock | Non
 @pytest.fixture
 def mock_model():
     model = MagicMock()
-    model.token_manager = TokenManager()
+    model.rollout = Rollout()
     return model
 
 

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -19,7 +19,7 @@ from strands.types.exceptions import (
     EventLoopException,
     MaxTokensReachedException,
 )
-from strands_sglang import MaxToolCallsReachedError, MaxToolIterationsReachedError, TokenManager
+from strands_sglang import MaxToolCallsReachedError, MaxToolIterationsReachedError
 
 from strands_env.core.types import (
     Action,
@@ -28,7 +28,6 @@ from strands_env.core.types import (
     StepResult,
     TaskContext,
     TerminationReason,
-    TokenObservation,
 )
 
 # ---------------------------------------------------------------------------
@@ -64,50 +63,6 @@ class TestAction:
         ctx = TaskContext(ground_truth="4")
         action = Action(message="What is 2+2?", task_context=ctx)
         assert action.task_context.ground_truth == "4"
-
-
-# ---------------------------------------------------------------------------
-# TokenObservation
-# ---------------------------------------------------------------------------
-
-
-class TestTokenObservation:
-    def test_rollout_slicing(self):
-        obs = TokenObservation(
-            token_ids=[10, 20, 30, 40, 50],
-            prompt_length=2,
-            loss_mask=[0, 0, 1, 1, 1],
-            logprobs=[None, None, -0.5, -0.3, -0.1],
-        )
-        assert obs.initial_prompt_token_ids == [10, 20]
-        assert obs.rollout_token_ids == [30, 40, 50]
-        assert obs.rollout_loss_mask == [1, 1, 1]
-        assert obs.rollout_logprobs == [-0.5, -0.3, -0.1]
-
-    def test_from_token_manager_empty(self):
-        tm = TokenManager()
-        assert TokenObservation.from_token_manager(tm) is None
-
-    def test_from_token_manager(self):
-        tm = TokenManager()
-        tm.add_prompt([1, 2, 3])
-        tm.add_response([4, 5], logprobs=[-0.1, -0.2])
-        obs = TokenObservation.from_token_manager(tm)
-        assert obs is not None
-        assert obs.token_ids == [1, 2, 3, 4, 5]
-        assert obs.prompt_length == 3
-        assert obs.rollout_token_ids == [4, 5]
-
-    def test_from_token_manager_uses_initial_prompt(self):
-        """Verify prompt_length is derived from the first segment."""
-        tm = TokenManager()
-        tm.add_prompt([10, 20])
-        tm.add_response([30])
-        tm.add_prompt([40])
-        tm.add_response([50])
-        obs = TokenObservation.from_token_manager(tm)
-        assert obs.prompt_length == 2
-        assert obs.initial_prompt_token_ids == [10, 20]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_evaluator.py
+++ b/tests/unit/eval/test_evaluator.py
@@ -18,8 +18,9 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from strands_sglang import Rollout
 
-from strands_env.core import Action, Observation, RewardResult, StepResult, TaskContext, TokenObservation
+from strands_env.core import Action, Observation, RewardResult, StepResult, TaskContext
 from strands_env.eval import EvalSample, Evaluator
 from strands_env.eval.metrics import compute_pass_at_k
 
@@ -130,17 +131,17 @@ class TestEvaluator:
         assert results == {}
         mock_env.step.assert_not_awaited()
 
-    async def test_tokens_stripped_by_default(self, tmp_path):
-        """Token observation is stripped from results when keep_tokens=False (default)."""
-        token_obs = TokenObservation(
-            token_ids=[1, 2, 3], prompt_length=1, loss_mask=[0, 1, 1], logprobs=[None, -0.5, -0.3]
-        )
+    async def test_rollout_stripped_by_default(self, tmp_path):
+        """Token rollout is stripped from results when keep_rollout=False (default)."""
+        rollout = Rollout()
+        rollout.add_prompt([1])
+        rollout.add_response([2, 3], logprobs=[-0.5, -0.3])
 
         async def factory(action):
             env = MagicMock()
             env.reset = AsyncMock()
             env.step = AsyncMock(
-                return_value=StepResult(observation=Observation(tokens=token_obs)),
+                return_value=StepResult(observation=Observation(rollout=rollout)),
             )
             env.cleanup = AsyncMock()
             return env
@@ -148,7 +149,7 @@ class TestEvaluator:
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
         results = await evaluator.run([Action(message="q", task_context=TaskContext(id="p1"))])
 
-        assert results["p1"][0].step_result.observation.tokens is None
+        assert results["p1"][0].step_result.observation.rollout is None
 
     async def test_cleanup_called_on_step_error(self, tmp_path):
         """env.cleanup() is called even when env.step() raises."""
@@ -469,18 +470,18 @@ class TestDistributedEvaluation:
 
         assert sample.aborted
 
-    async def test_pool_tokens_stripped(self, tmp_path):
-        """Token observation is stripped from pool results when keep_tokens=False."""
-        token_obs = TokenObservation(
-            token_ids=[1, 2, 3], prompt_length=1, loss_mask=[0, 1, 1], logprobs=[None, -0.5, -0.3]
-        )
+    async def test_pool_rollout_stripped(self, tmp_path):
+        """Token rollout is stripped from pool results when keep_rollout=False."""
+        rollout = Rollout()
+        rollout.add_prompt([1])
+        rollout.add_response([2, 3], logprobs=[-0.5, -0.3])
         mock_pool = MagicMock()
-        mock_pool.step = AsyncMock(return_value=StepResult(observation=Observation(tokens=token_obs)))
+        mock_pool.step = AsyncMock(return_value=StepResult(observation=Observation(rollout=rollout)))
 
         evaluator = Evaluator(env_actor_pool=mock_pool, output_path=tmp_path / "results.jsonl")
         results = await evaluator.run([Action(message="q", task_context=TaskContext(id="p1"))])
 
-        assert results["p1"][0].step_result.observation.tokens is None
+        assert results["p1"][0].step_result.observation.rollout is None
 
     async def test_init_requires_factory_or_pool(self, tmp_path):
         """ValueError raised when neither env_factory nor env_actor_pool is provided."""


### PR DESCRIPTION
## Summary

Adopts strands-sglang's `Rollout` as the canonical token-level trajectory on `Observation`, retiring the parallel `TokenObservation` type. Requires `strands-sglang>=0.4.1` (ships `Rollout` + `Rollout.initial_prompt_length`).

## Changes

**Migration: TokenObservation → Rollout**
- `Observation.tokens: TokenObservation | None` → `Observation.rollout: Rollout | None`
- Removed `TokenObservation` and its `from_token_manager` constructor
- Dropped the separate `Observation.routed_experts` field — routed experts now live in `Rollout.routed_experts`
- `Environment.step` reads `agent.model.rollout` directly (no more `TokenManager`)
- Prompt/response slicing uses `Rollout.initial_prompt_length` (strands-sglang #67) in slime logging and the integration `assert_rollout` helper
- Renamed the `Evaluator` flag `keep_tokens` → `keep_rollout` (`--keep-tokens` → `--keep-rollout`)
- Bumped pin to `strands-sglang>=0.4.1`

**Folded-in fix: model-id resolution (#53 regression)**
- `get_model_id` now reads `/get_model_info` (`tokenizer_path`/`model_path`, org-prefixed HF id) instead of `/v1/models` (the *served* name). The served name (e.g. `Qwen3-30B-A3B-Instruct-2507`) isn't a valid HF repo, so `AutoTokenizer.from_pretrained` 404s — this fixes the model factory and integration tests, and re-converges with strands-sglang's conftest.

## Testing
- Unit: **178 passed**
- Integration (live SGLang + Bedrock AgentCore): calculator **5 passed**, code_sandbox **6 passed**
- Live `initial_prompt_length` smoke test passed; agentic multi-turn rollout inspected
- ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)