### PR TITLE
feat(harbor): add e2b backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,15 @@ harbor = [
     "harbor-aws==0.4.0; python_version>='3.12'",
     "awscli; python_version>='3.12'",
 ]
+# Self-hosted e2b sandbox backend for Harbor. Adds the `"e2b"` backend to the
+# `harbor` env, so install alongside it: `strands-env[harbor,e2b]`.
+e2b = [
+    "e2b==2.25.1",
+    "httpx",
+    "httpcore",
+    "h2",
+    "packaging",
+]
 ifeval = ["lm_eval[ifeval]>=0.4.11"]
 agent-world-model = ["agent-world-model==0.1.0; python_version>='3.12'"]
 

--- a/src/strands_env/environments/harbor/_e2b_aws.py
+++ b/src/strands_env/environments/harbor/_e2b_aws.py
@@ -1,0 +1,297 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""e2b-on-AWS template adapter for the Harbor `e2b` backend.
+
+Some self-hosted e2b deployments don't implement Harbor's auto-build template
+route. This adapter subclasses Harbor's `E2BEnvironment` to skip that path and
+boot from a `template_id` resolved from a `templates.json` mapping (or the
+`E2B_TEMPLATES_PATH` env var).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import random
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypeVar
+
+import e2b.api as _e2b_api
+import httpx
+from e2b.exceptions import AuthenticationException
+from harbor.environments.e2b import E2BEnvironment
+from harbor.models.trial.paths import EnvironmentPaths
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from harbor.models.task.config import EnvironmentConfig as HarborEnvironmentConfig
+    from harbor.models.trial.paths import TrialPaths
+
+logger = logging.getLogger(__name__)
+
+
+def _permissive_validate_api_key(api_key: str) -> None:
+    if not isinstance(api_key, str) or not api_key.startswith("e2b_") or len(api_key) <= 4:
+        raise AuthenticationException('Invalid API key format: expected "e2b_" followed by a non-empty body.')
+
+
+# The upstream e2b SDK validates API keys against a hex-only regex. Some
+# self-hosted deployments mint keys from a broader `[a-z0-9]` alphabet, which
+# the SDK would reject client-side. Relax the validator to only require the
+# `e2b_` prefix + non-empty body. No-op for standard hex keys. Applied at import
+# time, before harbor's E2BEnvironment constructs any Sandbox.
+_e2b_api.validate_api_key = _permissive_validate_api_key
+
+_RETRYABLE_HTTP2_ERRORS: tuple[type[BaseException], ...] = (
+    httpx.RemoteProtocolError,
+    httpx.ConnectError,
+    httpx.ReadError,
+    httpx.WriteError,
+)
+
+T = TypeVar("T")
+
+
+async def _retry_on_http2_transient(
+    op: Callable[[], Awaitable[T]],
+    *,
+    op_name: str,
+    max_attempts: int = 3,
+    initial_backoff_s: float = 0.05,
+) -> T:
+    """Run *op* with bounded exponential backoff on HTTP/2 transients.
+
+    Retries only on the classes in `_RETRYABLE_HTTP2_ERRORS`; any other
+    exception is re-raised immediately so test failures, missing files, etc.
+    are not silently retried. Backoff is exponential with jitter starting at
+    50ms.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await op()
+        except _RETRYABLE_HTTP2_ERRORS as e:
+            last_exc = e
+            if attempt == max_attempts:
+                logger.warning(
+                    "%s: giving up after %d attempts on %s: %s",
+                    op_name,
+                    attempt,
+                    type(e).__name__,
+                    e,
+                )
+                raise
+            sleep_s = initial_backoff_s * (2 ** (attempt - 1)) * (1 + random.random())
+            logger.info(
+                "%s: retry %d/%d after %s: %s (sleep %.2fs)",
+                op_name,
+                attempt,
+                max_attempts,
+                type(e).__name__,
+                e,
+                sleep_s,
+            )
+            await asyncio.sleep(sleep_s)
+    # Unreachable — final attempt either returned or re-raised. Satisfy type checker.
+    assert last_exc is not None
+    raise last_exc
+
+
+def _load_template_map(path: str | Path) -> dict[str, str]:
+    """Load a {task_name: template_id} mapping from a JSON file.
+
+    The file maps each Harbor task name to a template id baked against the
+    self-hosted e2b cluster.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(
+            f"Templates file not found at {p}. Bake the task templates against the e2b cluster first.",
+        )
+    data = json.loads(p.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{p} must contain a JSON object mapping task_name -> template_id.")
+    return data
+
+
+def resolve_template_id(task_name: str, template_map_path: str | Path | None = None) -> str:
+    """Resolve a Harbor task name to its e2b template id.
+
+    Args:
+        task_name: The task's name (e.g. `"fix-git"`). Matches the directory
+            name in the dataset and the `Task.name` field after Harbor's
+            mapper has run.
+        template_map_path: Path to `templates.json`. If None, reads from
+            `E2B_TEMPLATES_PATH`.
+
+    Raises:
+        FileNotFoundError: If the templates file does not exist.
+        KeyError: If the task name has no entry. A template must be baked for
+            new tasks before they can be evaluated.
+    """
+    if template_map_path is None:
+        template_map_path = os.environ.get("E2B_TEMPLATES_PATH")
+    if template_map_path is None:
+        raise RuntimeError(
+            "E2B_TEMPLATES_PATH not set and no template_map_path provided. "
+            "Set it to a templates.json mapping task_name -> template_id.",
+        )
+    mapping = _load_template_map(template_map_path)
+    # Tolerate both Harbor's `<benchmark>/<task>` form (e.g. `terminal-bench/fix-git`)
+    # and the bare directory name (`fix-git`). The mapping uses the bare directory
+    # name; the evaluator passes Harbor's full Task.name.
+    candidates = [task_name, task_name.split("/")[-1]]
+    for candidate in candidates:
+        if candidate in mapping:
+            return mapping[candidate]
+    raise KeyError(
+        f"Task {task_name!r} has no template. "
+        f"Tried: {candidates}. "
+        f"Known tasks: {sorted(mapping.keys())[:10]}{'...' if len(mapping) > 10 else ''}. "
+        f"Bake the template for {candidates[-1]!r} first.",
+    )
+
+
+class E2bAWSEnvironment(E2BEnvironment):
+    """E2BEnvironment that skips Harbor's auto-build path.
+
+    Construction is identical to `E2BEnvironment` except a `template_id` kwarg
+    pins the template the sandbox should boot from.
+    """
+
+    # Harbor's reward.py checks `docker_env.is_mounted` to decide whether
+    # results need to be downloaded out of the environment. Mounted
+    # filesystems (Docker on Linux + bind mounts) skip the download because
+    # the host already sees the files. e2b sandboxes are remote — files only
+    # exist inside the microVM until downloaded, so this must be False.
+    is_mounted = False
+
+    def __init__(
+        self,
+        environment_dir: Path,
+        environment_name: str,
+        session_id: str,
+        trial_paths: TrialPaths,
+        task_env_config: HarborEnvironmentConfig,
+        *args: Any,
+        template_id: str,
+        **kwargs: Any,
+    ) -> None:
+        # Forward the five required fields positionally so any extra *args
+        # unpack cleanly after them. Passing them by keyword *before* `*args`
+        # (B026) would raise "multiple values for argument" the moment a
+        # positional extra is supplied, since `*args` binds to the same leading
+        # parameters.
+        super().__init__(
+            environment_dir,
+            environment_name,
+            session_id,
+            trial_paths,
+            task_env_config,
+            *args,
+            **kwargs,
+        )
+        self._template_id = template_id
+
+    @override
+    async def start(self, force_build: bool) -> None:
+        # Skip _does_template_exist + _create_template. Use the resolved id.
+        self._template_name = self._template_id
+        if force_build:
+            self.logger.warning(
+                "force_build=True requested but E2bAWSEnvironment ignores it. "
+                "Re-bake the template against the e2b cluster if needed.",
+            )
+        await self._create_sandbox()
+        if not self._sandbox:
+            raise RuntimeError("Sandbox not found but was just created.")
+        # Harbor convention: tasks read/write under /logs/{agent,verifier,artifacts}
+        # and /tests. The base E2BEnvironment.start() relies on Harbor's auto-build
+        # path to bake these into the image; this adapter skips that path so we
+        # must create them ourselves. Without these, reward.py's `tee /logs/
+        # verifier/test-stdout.txt` and `download_dir(/logs/verifier)` fail with
+        # FileNotFoundException for any task image that didn't pre-create the dirs.
+        # User-declared mount targets are unioned in so explicit volumes still work.
+        harbor_dirs = [
+            EnvironmentPaths.logs_dir,
+            EnvironmentPaths.agent_dir,
+            EnvironmentPaths.verifier_dir,
+            EnvironmentPaths.artifacts_dir,
+            EnvironmentPaths.tests_dir,
+        ]
+        mount_targets = self._mount_targets(writable_only=True)
+        await self.ensure_dirs([*harbor_dirs, *mount_targets])
+        # Preserve base E2BEnvironment.start() semantics: prebuilt-image tasks
+        # that ship supplemental files under environment/ (no Dockerfile /
+        # compose) rely on this to copy them into the sandbox workdir. The
+        # method self-guards (no-ops when should_upload_environment_dir is
+        # False), so it's safe for tasks that don't need it.
+        await self._upload_environment_dir_after_start()
+
+    @override
+    async def _create_template(self) -> None:  # type: ignore[override]
+        # Surface a precise error if Harbor ever falls into this path (it
+        # shouldn't, since we override start; but defensive).
+        raise RuntimeError(
+            "E2bAWSEnvironment does not auto-build templates. "
+            "Templates must be baked against the e2b cluster before eval.",
+        )
+
+    # These four overrides wrap harbor's E2BEnvironment file-transfer calls in
+    # the same bounded-retry policy `Sandbox.create` already uses internally,
+    # so a transient HTTP/2 drop on a verifier round-trip (HarborReward.compute
+    # → upload_dir + download_dir) doesn't drop a whole task from the pass@k
+    # denominator. These ops are idempotent — re-running them re-transfers the
+    # same bytes — so retry is always safe here.
+    #
+    # `exec` is deliberately NOT wrapped: a retry after a *post-dispatch*
+    # transient (the command already started server-side, but the client failed
+    # reading the response) would silently run the command twice. That's
+    # harmless for the idempotent verifier `test.sh` but unsafe for arbitrary
+    # agent commands, and `exec` can't tell the two callers apart. Retrying the
+    # known-idempotent verifier exec is tracked separately (a future
+    # `exec_idempotent` entry point the verifier opts into). Until then `exec`
+    # inherits the base, un-retried behavior.
+
+    @override
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        await _retry_on_http2_transient(
+            lambda: super(E2bAWSEnvironment, self).upload_file(source_path, target_path),
+            op_name=f"upload_file({target_path})",
+        )
+
+    @override
+    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+        await _retry_on_http2_transient(
+            lambda: super(E2bAWSEnvironment, self).upload_dir(source_dir, target_dir),
+            op_name=f"upload_dir({target_dir})",
+        )
+
+    @override
+    async def download_file(self, source_path: str, target_path: Path | str) -> None:
+        await _retry_on_http2_transient(
+            lambda: super(E2bAWSEnvironment, self).download_file(source_path, target_path),
+            op_name=f"download_file({source_path})",
+        )
+
+    @override
+    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+        await _retry_on_http2_transient(
+            lambda: super(E2bAWSEnvironment, self).download_dir(source_dir, target_dir),
+            op_name=f"download_dir({source_dir})",
+        )

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -23,6 +23,7 @@ environment — they differ only in their dataset and system prompt (set per-ben
 
 from __future__ import annotations
 
+import os
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeAlias
@@ -56,15 +57,20 @@ class HarborConfig(EnvironmentConfig):
     Backends:
         - "docker": Local Docker via `harbor`'s native `DockerEnvironment`.
         - "eks": AWS EKS/Fargate via `harbor-aws`'s `AWSEnvironment`.
+        - "e2b": Self-hosted e2b sandbox (Firecracker microVM, e2b-on-AWS) via
+            `E2bAWSEnvironment`. Connection (`domain`/`api_key`) and template
+            config go in `e2b_backend_config`, or fall back to the
+            `E2B_DOMAIN` / `E2B_API_KEY` env vars.
     """
 
     task_id: str
     task_dir: str
     trial_dir: str
     timeout: NotRequired[int]
-    backend: NotRequired[Literal["docker", "eks"]]
+    backend: NotRequired[Literal["docker", "eks", "e2b"]]
     harbor_env_config: NotRequired[HarborEnvironmentConfig]
     eks_backend_config: NotRequired[EKSBackendConfig]
+    e2b_backend_config: NotRequired[E2bBackendConfig]
 
 
 class EKSBackendConfig(TypedDict, total=False):
@@ -74,6 +80,37 @@ class EKSBackendConfig(TypedDict, total=False):
     region: str
     ecr_cache: bool
     role_arn: str | None
+
+
+class E2bBackendConfig(TypedDict, total=False):
+    """Configuration for the e2b backend.
+
+    Every field is optional and serializable, so a run is fully reproducible
+    from config alone (mirrors `EKSBackendConfig`). `domain`/`api_key`, when
+    provided, are written back into `E2B_DOMAIN`/`E2B_API_KEY` before the
+    sandbox is built, because the underlying harbor `E2BEnvironment` + e2b SDK
+    read those env vars directly. When omitted, the existing process env vars
+    are used as-is.
+    """
+
+    # e2b cluster API domain. Falls back to the `E2B_DOMAIN` env var when unset.
+    domain: str
+    # e2b API key. Falls back to the `E2B_API_KEY` env var when unset. NOTE:
+    # supplying this via config serializes it into the run config/logs; prefer
+    # `api_key_file` or the env var if that's a concern.
+    api_key: str
+    # Path to a file containing the e2b API key (read + stripped at reset time).
+    # Keeps the secret out of --env-config / config.json / shell history. Used
+    # only when `api_key` is not set. `~` is expanded.
+    api_key_file: str
+    # Template id for the task. Optional: when omitted, the adapter resolves
+    # the id from `templates_json` (or `E2B_TEMPLATES_PATH`) using the task
+    # name as the lookup key.
+    template_id: str
+    # Path to a templates.json {task_name: template_id} mapping. Falls back to
+    # the `E2B_TEMPLATES_PATH` env var when unset. Required (via either source)
+    # unless `template_id` is provided directly.
+    templates_json: str
 
 
 class HarborEnv(Environment):
@@ -94,11 +131,12 @@ class HarborEnv(Environment):
         self.task_paths = TaskPaths(Path(str(self.config["task_dir"])))
         self.trial_paths = TrialPaths(Path(str(self.config["trial_dir"])))
         self.timeout: int = int(self.config.get("timeout", 1200))
-        self.backend: Literal["docker", "eks"] = self.config.get("backend", "docker")
+        self.backend: Literal["docker", "eks", "e2b"] = self.config.get("backend", "docker")
         self.harbor_env_config: HarborEnvironmentConfig = self.config.get(
             "harbor_env_config", HarborEnvironmentConfig()
         )
         self.eks_backend_config: EKSBackendConfig = self.config.get("eks_backend_config", {})
+        self.e2b_backend_config: E2bBackendConfig = self.config.get("e2b_backend_config", {})
         self.docker_env: HarborEnvironment | AWSEnvironment | None = None
         self.reward_fn = reward_fn or HarborReward(self)
 
@@ -108,6 +146,7 @@ class HarborEnv(Environment):
         self.trial_paths.mkdir()
         session_id = f"{self.task_id}-{uuid.uuid4().hex[:8]}"
 
+        force_build = True
         match self.backend:
             case "docker":
                 self.docker_env = EnvironmentFactory.create_environment(
@@ -130,8 +169,35 @@ class HarborEnv(Environment):
                     task_env_config=self.harbor_env_config,
                     **self.eks_backend_config,
                 )
+            case "e2b":
+                from ._e2b_aws import E2bAWSEnvironment, resolve_template_id
 
-        await self.docker_env.start(force_build=True)
+                if domain := self.e2b_backend_config.get("domain"):
+                    os.environ["E2B_DOMAIN"] = domain
+                if api_key := self.e2b_backend_config.get("api_key"):
+                    os.environ["E2B_API_KEY"] = api_key
+                elif api_key_file := self.e2b_backend_config.get("api_key_file"):
+                    key = Path(api_key_file).expanduser().read_text().strip()
+                    if not key:
+                        raise ValueError(f"e2b api_key_file is empty: {api_key_file}")
+                    os.environ["E2B_API_KEY"] = key
+
+                template_id = self.e2b_backend_config.get("template_id") or resolve_template_id(
+                    task_name=self.task_id,
+                    template_map_path=self.e2b_backend_config.get("templates_json"),
+                )
+                # force_build is ignored by E2bAWSEnvironment; templates are static.
+                force_build = False
+                self.docker_env = E2bAWSEnvironment(
+                    environment_dir=self.task_paths.environment_dir,
+                    environment_name=session_id,
+                    session_id=session_id,
+                    trial_paths=self.trial_paths,
+                    task_env_config=self.harbor_env_config,
+                    template_id=template_id,
+                )
+
+        await self.docker_env.start(force_build=force_build)
 
     @tool
     async def execute_command(self, command: str) -> str:

--- a/tests/unit/environments/harbor/test_e2b_aws.py
+++ b/tests/unit/environments/harbor/test_e2b_aws.py
@@ -1,0 +1,331 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Harbor `e2b` backend adapter (`_e2b_aws.py`).
+
+Covers the harbor-independent logic: template resolution, the templates.json
+loader, the HTTP/2-transient retry helper, the permissive api-key validator,
+and the `E2bAWSEnvironment` overrides (build-skip, Harbor dir creation, the
+retry-wrapped file/exec methods). Harbor's `E2BEnvironment` base and the e2b
+SDK are not exercised against a real cluster — sandbox creation is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+# The adapter subclasses harbor's E2BEnvironment, so the module can't import
+# without harbor. Skip the whole file when harbor isn't installed (matches the
+# convention in tests/integration/test_harbor.py).
+pytest.importorskip("harbor", reason="harbor>=0.1.43 required for the e2b backend adapter")
+
+from e2b.exceptions import AuthenticationException  # noqa: E402
+
+from strands_env.environments.harbor import _e2b_aws  # noqa: E402
+from strands_env.environments.harbor._e2b_aws import (  # noqa: E402
+    E2bAWSEnvironment,
+    _load_template_map,
+    _permissive_validate_api_key,
+    _retry_on_http2_transient,
+    resolve_template_id,
+)
+
+# ---------------------------------------------------------------------------
+# _permissive_validate_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestPermissiveValidateApiKey:
+    """The relaxed api-key validator monkey-patched onto the e2b SDK."""
+
+    def test_accepts_hex_key(self):
+        """A standard hex key passes (no-op for upstream keys)."""
+        _permissive_validate_api_key("e2b_0123456789abcdef")  # no raise
+
+    def test_accepts_non_hex_alnum_key(self):
+        """A self-hosted `[a-z0-9]` key passes (the reason the patch exists)."""
+        _permissive_validate_api_key("e2b_3fw7jq32e71yfqu0")  # no raise
+
+    def test_rejects_missing_prefix(self):
+        """A key without the `e2b_` prefix is rejected."""
+        with pytest.raises(AuthenticationException):
+            _permissive_validate_api_key("sk_0123456789")
+
+    def test_rejects_empty_body(self):
+        """`e2b_` with no body (len <= 4) is rejected."""
+        with pytest.raises(AuthenticationException):
+            _permissive_validate_api_key("e2b_")
+
+    def test_rejects_non_string(self):
+        """A non-string key is rejected, not crashed on."""
+        with pytest.raises(AuthenticationException):
+            _permissive_validate_api_key(None)  # type: ignore[arg-type]
+
+    def test_patch_is_installed_on_e2b_sdk(self):
+        """Importing the module installs the validator on e2b.api at module load."""
+        assert _e2b_api_validator() is _permissive_validate_api_key
+
+
+def _e2b_api_validator():
+    import e2b.api as api
+
+    return api.validate_api_key
+
+
+# ---------------------------------------------------------------------------
+# _load_template_map
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTemplateMap:
+    """Loading + validating a templates.json file."""
+
+    def test_loads_valid_mapping(self, tmp_path: Path):
+        """A JSON object is returned as a dict."""
+        p = tmp_path / "templates.json"
+        p.write_text(json.dumps({"fix-git": "tmpl-abc", "make-doc": "tmpl-def"}))
+        assert _load_template_map(p) == {"fix-git": "tmpl-abc", "make-doc": "tmpl-def"}
+
+    def test_missing_file_raises_filenotfound(self, tmp_path: Path):
+        """A nonexistent path raises FileNotFoundError with guidance."""
+        with pytest.raises(FileNotFoundError, match="Templates file not found"):
+            _load_template_map(tmp_path / "nope.json")
+
+    def test_non_dict_json_raises_valueerror(self, tmp_path: Path):
+        """A JSON array (or any non-object) raises a clear ValueError."""
+        p = tmp_path / "bad.json"
+        p.write_text(json.dumps(["fix-git", "make-doc"]))
+        with pytest.raises(ValueError, match="must contain a JSON object"):
+            _load_template_map(p)
+
+    def test_accepts_str_path(self, tmp_path: Path):
+        """A str path (not just Path) works."""
+        p = tmp_path / "templates.json"
+        p.write_text(json.dumps({"t": "id"}))
+        assert _load_template_map(str(p)) == {"t": "id"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_template_id
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTemplateId:
+    """Resolving a task name to its template id."""
+
+    @pytest.fixture
+    def templates(self, tmp_path: Path) -> Path:
+        p = tmp_path / "templates.json"
+        p.write_text(json.dumps({"fix-git": "tmpl-fixgit", "make-doc": "tmpl-makedoc"}))
+        return p
+
+    def test_direct_name_hit(self, templates: Path):
+        """A bare task name resolves directly."""
+        assert resolve_template_id("fix-git", templates) == "tmpl-fixgit"
+
+    def test_benchmark_prefixed_name_falls_back_to_bare(self, templates: Path):
+        """Harbor's `<benchmark>/<task>` form falls back to the bare dir name."""
+        assert resolve_template_id("terminal-bench/fix-git", templates) == "tmpl-fixgit"
+
+    def test_reads_env_var_when_path_is_none(self, templates: Path, monkeypatch):
+        """With no explicit path, E2B_TEMPLATES_PATH is used."""
+        monkeypatch.setenv("E2B_TEMPLATES_PATH", str(templates))
+        assert resolve_template_id("make-doc") == "tmpl-makedoc"
+
+    def test_missing_env_var_and_path_raises_runtimeerror(self, monkeypatch):
+        """No path + unset env var raises an actionable RuntimeError."""
+        monkeypatch.delenv("E2B_TEMPLATES_PATH", raising=False)
+        with pytest.raises(RuntimeError, match="E2B_TEMPLATES_PATH not set"):
+            resolve_template_id("fix-git")
+
+    def test_unknown_task_raises_keyerror(self, templates: Path):
+        """A task absent from the mapping raises KeyError listing what was tried."""
+        with pytest.raises(KeyError, match="has no template"):
+            resolve_template_id("never-baked", templates)
+
+    def test_explicit_path_overrides_env_var(self, templates: Path, tmp_path: Path, monkeypatch):
+        """An explicit template_map_path wins over E2B_TEMPLATES_PATH."""
+        other = tmp_path / "other.json"
+        other.write_text(json.dumps({"fix-git": "from-env-var"}))
+        monkeypatch.setenv("E2B_TEMPLATES_PATH", str(other))
+        # explicit `templates` maps fix-git -> tmpl-fixgit, not from-env-var
+        assert resolve_template_id("fix-git", templates) == "tmpl-fixgit"
+
+
+# ---------------------------------------------------------------------------
+# _retry_on_http2_transient
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOnHttp2Transient:
+    """The bounded-retry helper for HTTP/2 transients."""
+
+    async def test_returns_on_first_success(self):
+        """A call that succeeds immediately runs exactly once."""
+        op = AsyncMock(return_value="ok")
+        result = await _retry_on_http2_transient(op, op_name="x", initial_backoff_s=0.0)
+        assert result == "ok"
+        assert op.call_count == 1
+
+    async def test_retries_then_succeeds(self):
+        """A retryable transient is retried until the call succeeds."""
+        op = AsyncMock(side_effect=[httpx.ReadError("boom"), "ok"])
+        result = await _retry_on_http2_transient(op, op_name="x", initial_backoff_s=0.0)
+        assert result == "ok"
+        assert op.call_count == 2
+
+    async def test_exhausts_attempts_and_reraises(self):
+        """All attempts failing re-raises the last transient after max_attempts."""
+        op = AsyncMock(side_effect=httpx.ConnectError("always"))
+        with pytest.raises(httpx.ConnectError):
+            await _retry_on_http2_transient(op, op_name="x", max_attempts=3, initial_backoff_s=0.0)
+        assert op.call_count == 3
+
+    async def test_non_retryable_raises_immediately(self):
+        """A non-transient error propagates on the first attempt (no retry)."""
+        op = AsyncMock(side_effect=ValueError("nope"))
+        with pytest.raises(ValueError):
+            await _retry_on_http2_transient(op, op_name="x", initial_backoff_s=0.0)
+        assert op.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# E2bAWSEnvironment
+# ---------------------------------------------------------------------------
+
+
+def _make_env() -> E2bAWSEnvironment:
+    """Build an E2bAWSEnvironment without running harbor's heavy __init__.
+
+    We bypass __init__ (which would touch the e2b SDK / harbor internals) and
+    set only the attributes the methods under test read, so the override logic
+    is exercised in isolation.
+    """
+    env = E2bAWSEnvironment.__new__(E2bAWSEnvironment)
+    env._template_id = "tmpl-pinned"
+    env._sandbox = MagicMock()
+    env.logger = MagicMock()
+    return env
+
+
+class TestE2bAWSEnvironmentConstruction:
+    """Constructor + class-level attributes."""
+
+    def test_init_stores_template_id(self):
+        """The `template_id` kwarg is recorded as `_template_id`."""
+        with patch.object(_e2b_aws.E2BEnvironment, "__init__", return_value=None) as base_init:
+            env = E2bAWSEnvironment(
+                Path("/env"),
+                "env-name",
+                "sess-1",
+                MagicMock(),  # trial_paths
+                MagicMock(),  # task_env_config
+                template_id="tmpl-xyz",
+            )
+        assert env._template_id == "tmpl-xyz"
+        base_init.assert_called_once()
+
+    def test_is_mounted_is_false(self):
+        """e2b sandboxes are remote, so is_mounted must be False (drives result download)."""
+        assert E2bAWSEnvironment.is_mounted is False
+
+
+class TestE2bAWSEnvironmentStart:
+    """The `start()` override: skip build, create dirs, upload env dir."""
+
+    async def test_start_pins_template_and_creates_dirs(self):
+        """start() sets _template_name to the pinned id and ensure_dirs the Harbor paths."""
+        env = _make_env()
+        env._create_sandbox = AsyncMock()
+        env._mount_targets = MagicMock(return_value=["/work"])
+        env.ensure_dirs = AsyncMock()
+        env._upload_environment_dir_after_start = AsyncMock()
+
+        await env.start(force_build=False)
+
+        assert env._template_name == "tmpl-pinned"
+        env._create_sandbox.assert_awaited_once()
+        env.ensure_dirs.assert_awaited_once()
+        # ensure_dirs gets the 5 standard Harbor dirs + the mount targets.
+        passed = env.ensure_dirs.call_args.args[0]
+        assert "/work" in passed
+        assert len(passed) >= 6
+        env._upload_environment_dir_after_start.assert_awaited_once()
+
+    async def test_start_warns_but_ignores_force_build(self):
+        """force_build=True is ignored (templates are static) but logged."""
+        env = _make_env()
+        env._create_sandbox = AsyncMock()
+        env._mount_targets = MagicMock(return_value=[])
+        env.ensure_dirs = AsyncMock()
+        env._upload_environment_dir_after_start = AsyncMock()
+
+        await env.start(force_build=True)
+
+        env.logger.warning.assert_called_once()
+        assert env._template_name == "tmpl-pinned"
+
+    async def test_start_raises_when_sandbox_not_created(self):
+        """If _create_sandbox leaves no sandbox, start() fails loudly."""
+        env = _make_env()
+        env._sandbox = None
+        env._create_sandbox = AsyncMock()
+        env._mount_targets = MagicMock(return_value=[])
+        env.ensure_dirs = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="Sandbox not found"):
+            await env.start(force_build=False)
+
+    async def test_create_template_raises(self):
+        """The auto-build path is disabled and raises a precise error."""
+        env = _make_env()
+        with pytest.raises(RuntimeError, match="does not auto-build templates"):
+            await env._create_template()
+
+
+class TestE2bAWSEnvironmentRetryWrappers:
+    """The idempotent file-transfer overrides delegate to the base through the retry helper."""
+
+    async def test_upload_file_delegates_to_base(self):
+        """upload_file() routes through the base implementation."""
+        env = _make_env()
+        with patch.object(_e2b_aws.E2BEnvironment, "upload_file", new=AsyncMock()) as base_upload:
+            await env.upload_file("/src", "/dst")
+        base_upload.assert_awaited_once()
+
+    async def test_upload_file_retries_transient_then_succeeds(self):
+        """A transient on the first attempt is retried via the helper (idempotent op)."""
+        env = _make_env()
+        base_upload = AsyncMock(side_effect=[httpx.RemoteProtocolError("drop"), None])
+        with patch.object(_e2b_aws.E2BEnvironment, "upload_file", new=base_upload):
+            await env.upload_file("/src", "/dst")
+        assert base_upload.await_count == 2
+
+    async def test_download_dir_delegates_to_base(self):
+        """download_dir() routes through the base implementation."""
+        env = _make_env()
+        with patch.object(_e2b_aws.E2BEnvironment, "download_dir", new=AsyncMock()) as base_download:
+            await env.download_dir("/remote", "/local")
+        base_download.assert_awaited_once()
+
+    def test_exec_is_not_overridden(self):
+        """`exec` must NOT be wrapped in retry: a post-dispatch retry could double-run a
+        non-idempotent agent command. The adapter inherits the base, un-retried `exec`.
+        (Retrying the known-idempotent verifier exec is tracked as separate work.)"""
+        assert "exec" not in E2bAWSEnvironment.__dict__


### PR DESCRIPTION
## What

Adds an `e2b` backend to `HarborEnv` so Harbor-format tasks can run on a self-hosted e2b cluster instead of local Docker or EKS. The backend boots from a prebuilt e2b template id, keeps the existing `execute_command` and `HarborReward` contract, and is selected through serializable env config (`backend="e2b"`).

## Why

Some self-hosted e2b deployments do not support Harbor template auto-build. This adapter lets evals use templates baked ahead of time for the target cluster, while preserving the generic Harbor task abstraction used by terminal-bench and SWE-bench.

## Changes

- Add an `e2b` optional dependency extra for the Harbor e2b backend.
- Extend `HarborConfig` with `backend="e2b"` and `e2b_backend_config` for domain, API key, template id, and template map settings.
- Add `E2bAWSEnvironment`, a Harbor `E2BEnvironment` adapter that skips auto-build, resolves template ids from config or `E2B_TEMPLATES_PATH`, creates Harbor log/test directories, and marks the remote sandbox as unmounted so verifier artifacts are downloaded.
- Wrap idempotent file-transfer operations with bounded retry for transient HTTP/2 failures.
- Leave `exec` unwrapped to avoid double-running agent commands after post-dispatch transport errors.
- Relax the e2b SDK API-key validator for self-hosted non-hex keys.
- Add unit coverage for template resolution, API-key validation, retry behavior, start-time setup, and the no-retry `exec` decision.
- Rebuild the terminal-bench task context model after importing `AttributeValue` at runtime so Harbor eval configs validate under Pydantic.

## Verification

- `ruff check src/strands_env/environments/harbor/ tests/unit/environments/harbor/`
- `ruff format --check src/strands_env/environments/harbor/ tests/unit/environments/harbor/`
- `mypy src/strands_env`
- `python -m pytest tests/unit/environments/harbor/test_e2b_aws.py`
- `python -m pytest tests/unit/`
- End-to-end terminal-bench smoke run against the self-hosted e2b cluster: sandbox creation, agent shell commands, verifier execution, and reward file download all completed successfully.