### PR TITLE
build(deps): bump strands-sglang floor to >=0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-sglang>=0.4.1",
+    "strands-sglang>=0.4.2",
     "strands-agents-tools>=0.2.0",
     "openai",
     "datasets",


### PR DESCRIPTION
## What

Raise the `strands-sglang` minimum from `>=0.4.1` to `>=0.4.2` (the latest release, published 2026-06-13).

## Verification

Upgraded `strands-sglang` to 0.4.2 in an isolated 3.12 venv and ran the unit suite — 206 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)