### PR TITLE
fix(environment): resolve config type hints at runtime for embedded Pydantic configs

### DIFF
--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -20,8 +20,9 @@ import logging
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
+from typing import Any, ClassVar, TypeAlias
 
+from opentelemetry.util.types import AttributeValue
 from strands import Agent
 from strands.agent.conversation_manager import ConversationManager, NullConversationManager
 from strands.handlers.callback_handler import PrintingCallbackHandler
@@ -37,9 +38,6 @@ from .types import (
     StepResult,
     TerminationReason,
 )
-
-if TYPE_CHECKING:
-    from opentelemetry.util.types import AttributeValue
 
 logger = logging.getLogger(__name__)
 

--- a/src/strands_env/environments/harbor/e2b.py
+++ b/src/strands_env/environments/harbor/e2b.py
@@ -30,26 +30,13 @@ import e2b.api as _e2b_api
 from e2b.exceptions import AuthenticationException
 from harbor.environments.e2b import E2BEnvironment
 from harbor.models.trial.paths import EnvironmentPaths
-from typing_extensions import TypedDict, override
+from typing_extensions import override
 
 if TYPE_CHECKING:
     from harbor.models.task.config import EnvironmentConfig as TaskEnvironmentConfig
     from harbor.models.trial.paths import TrialPaths
 
-
-class PrebakedE2BConfig(TypedDict, total=False):
-    """Connection + template config for the e2b backend (all fields optional)."""
-
-    # e2b cluster API domain (env: E2B_DOMAIN).
-    domain: str
-    # e2b API key (env: E2B_API_KEY); prefer `api_key_file` to keep it out of config.
-    api_key: str
-    # Read the e2b API key from this file instead of inlining it.
-    api_key_file: str
-    # Template to boot; falls back to a `templates_json` lookup by task name.
-    template_id: str
-    # {task_name: template_id} JSON map (env: E2B_TEMPLATES_PATH).
-    templates_json: str
+    from .env import PrebakedE2BConfig
 
 
 class PrebakedE2BEnvironment(E2BEnvironment):

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -33,7 +33,7 @@ from harbor.models.task.config import EnvironmentConfig as TaskEnvironmentConfig
 from harbor.models.task.paths import TaskPaths
 from harbor.models.trial.paths import TrialPaths
 from strands import tool
-from typing_extensions import NotRequired, Unpack, override
+from typing_extensions import NotRequired, TypedDict, Unpack, override
 
 from strands_env.core import Environment, ModelFactory
 from strands_env.core.environment import EnvironmentConfig
@@ -43,8 +43,6 @@ from .reward import HarborReward
 
 if TYPE_CHECKING:
     from harbor.environments.base import BaseEnvironment
-
-    from .e2b import PrebakedE2BConfig
 
     HarborEnvironment: TypeAlias = BaseEnvironment
 
@@ -67,6 +65,21 @@ class HarborConfig(EnvironmentConfig):
     backend: NotRequired[Literal["docker", "e2b"]]
     task_env_config: NotRequired[TaskEnvironmentConfig]
     prebaked_e2b_config: NotRequired[PrebakedE2BConfig]
+
+
+class PrebakedE2BConfig(TypedDict, total=False):
+    """Connection + template config for the e2b backend (all fields optional)."""
+
+    # e2b cluster API domain (env: E2B_DOMAIN).
+    domain: str
+    # e2b API key (env: E2B_API_KEY); prefer `api_key_file` to keep it out of config.
+    api_key: str
+    # Read the e2b API key from this file instead of inlining it.
+    api_key_file: str
+    # Template to boot; falls back to a `templates_json` lookup by task name.
+    template_id: str
+    # {task_name: template_id} JSON map (env: E2B_TEMPLATES_PATH).
+    templates_json: str
 
 
 class HarborEnv(Environment):

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -247,3 +247,27 @@ class TestComputeMetrics:
         result = env.compute_metrics(metrics)
 
         assert result["cache_hit_rate"] is None
+
+
+# ---------------------------------------------------------------------------
+# Config type-hint resolution
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentConfigTypeHints:
+    """`EnvironmentConfig` annotations must resolve at runtime.
+
+    Subclass configs are embedded as Pydantic fields by benchmark task contexts
+    (e.g. `config: HarborConfig`), so Pydantic resolves the hints at runtime. A
+    TYPE_CHECKING-only import in an annotation (e.g. `AttributeValue`) breaks
+    that with a `NameError`.
+    """
+
+    def test_type_hints_resolve(self):
+        """get_type_hints succeeds — no unresolved forward refs."""
+        import typing
+
+        from strands_env.core.environment import EnvironmentConfig
+
+        hints = typing.get_type_hints(EnvironmentConfig)
+        assert "trace_attributes" in hints

--- a/tests/unit/environments/harbor/test_env.py
+++ b/tests/unit/environments/harbor/test_env.py
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for `HarborConfig` type resolution.
+
+Regression guard: `HarborConfig` (with its nested `PrebakedE2BConfig` and the
+inherited `trace_attributes`) is embedded as a Pydantic field by the
+terminal-bench / swebench task contexts. Pydantic resolves those hints at
+runtime, so a TYPE_CHECKING-only type in any `HarborConfig` field breaks dataset
+loading with a `NameError`.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip("harbor", reason="harbor>=0.13.2 required for HarborConfig")
+
+from strands_env.environments.harbor.env import HarborConfig  # noqa: E402
+
+
+def test_harbor_config_type_hints_resolve():
+    """`HarborConfig` annotations resolve at runtime (incl. `prebaked_e2b_config`)."""
+    hints = typing.get_type_hints(HarborConfig)
+    assert "prebaked_e2b_config" in hints
+    assert "task_env_config" in hints
+    assert "trace_attributes" in hints  # inherited from EnvironmentConfig
+
+
+def test_harbor_config_embeds_in_pydantic_model():
+    """`HarborConfig` can back a Pydantic field (the terminal-bench TaskContext shape)."""
+
+    class _Ctx(BaseModel):
+        config: HarborConfig
+
+    _Ctx.model_rebuild()
+    ctx = _Ctx(config={"task_id": "t", "task_dir": "/d", "trial_dir": "/o"})
+    assert ctx.config["task_id"] == "t"


### PR DESCRIPTION
## What

The terminal-bench / swebench evaluators embed the env config as a Pydantic field (`TerminalBenchTaskContext.config: HarborConfig`), so Pydantic resolves that TypedDict's annotations **at runtime**. Two annotations referenced TYPE_CHECKING-only names, raising `NameError` (`... is not fully defined`) when the evaluator built its task context — crashing dataset loading before any task ran:

```
pydantic.errors.PydanticUserError: `TerminalBenchTaskContext` is not fully defined;
you should define `AttributeValue`, then call `TerminalBenchTaskContext.model_rebuild()`.
```

Found while running a real `terminal-bench-2` eval on the e2b backend.

## Root causes & fixes

- **`core/environment.py`** — `trace_attributes: dict[str, AttributeValue]` referenced `AttributeValue`, imported only under `TYPE_CHECKING`. `get_type_hints(EnvironmentConfig)` failed independently. Pre-existing since #130. → import it at runtime (`opentelemetry-api` is a hard dependency of `strands-agents`, always installed).
- **`harbor/env.py`** — the `prebaked_e2b_config: NotRequired[PrebakedE2BConfig]` field referenced `PrebakedE2BConfig`, which #139 had moved to `e2b.py` and imported under `TYPE_CHECKING`. → move the `PrebakedE2BConfig` TypedDict back to `env.py` (next to `HarborConfig`, which nests it). `e2b.py` keeps the `from_config` factory and references the type via `TYPE_CHECKING`.
  - Why not keep it in `e2b.py` + runtime-import? `e2b.py` is heavy (e2b SDK import + import-time api-key monkeypatch). Runtime-importing it from `env.py` would drag the e2b SDK + monkeypatch into every `import HarborEnv`, including the docker backend — defeating the deliberate lazy import. The lightweight config TypedDict belongs with `HarborConfig`; the heavy logic stays in `e2b.py`.

## Tests

- `get_type_hints(EnvironmentConfig)` resolves (core, no harbor needed).
- `get_type_hints(HarborConfig)` resolves incl. `prebaked_e2b_config`; `HarborConfig` can back a Pydantic field (reproduces the failure mode, decoupled from the benchmark).

## Verification

End-to-end `terminal-bench-2` on the e2b backend (Bedrock + self-hosted e2b cluster): dataset loads, task contexts build, sandboxes are created, the agent runs (`execute_command` round-trips), and rewards are computed from `test.sh`. `ruff`, `mypy`, and **209 unit tests** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)