### PR TITLE
refactor(harbor): rename sandbox, bind reward, restructure e2b adapter

### DIFF
--- a/src/strands_env/environments/harbor/e2b.py
+++ b/src/strands_env/environments/harbor/e2b.py
@@ -33,9 +33,6 @@ from harbor.models.trial.paths import EnvironmentPaths
 from typing_extensions import override
 
 if TYPE_CHECKING:
-    from harbor.models.task.config import EnvironmentConfig as TaskEnvironmentConfig
-    from harbor.models.trial.paths import TrialPaths
-
     from .env import PrebakedE2BConfig
 
 
@@ -46,45 +43,43 @@ class PrebakedE2BEnvironment(E2BEnvironment):
     already-baked template to boot from. Retries are inherited from the base.
     """
 
-    def __init__(self, *args: Any, template_id: str, **kwargs: Any) -> None:
+    def __init__(self, task_id: str, prebaked_e2b_config: PrebakedE2BConfig, *args: Any, **kwargs: Any) -> None:
         """Initialize a `PrebakedE2BEnvironment` instance.
 
-        `template_id` (keyword-only) pins the pre-baked template; the rest is
-        forwarded to `E2BEnvironment.__init__`.
+        Resolves the pinned template id from `prebaked_e2b_config` (an explicit
+        `template_id`, else a `templates.json` lookup by `task_id`) and exports the
+        e2b connection env vars; `*args`/`**kwargs` forward to `E2BEnvironment.__init__`.
         """
+        self.task_id = task_id
+        self._config = prebaked_e2b_config
+        self._template_id = self._config.get("template_id") or self._resolve_template_id()
+        self._set_e2b_env_vars()
         super().__init__(*args, **kwargs)
-        self._template_id = template_id
 
-    @classmethod
-    def from_config(
-        cls,
-        config: PrebakedE2BConfig,
-        *,
-        task_id: str,
-        environment_dir: Path,
-        environment_name: str,
-        session_id: str,
-        trial_paths: TrialPaths,
-        task_env_config: TaskEnvironmentConfig,
-    ) -> PrebakedE2BEnvironment:
-        """Build a `PrebakedE2BEnvironment` from a `PrebakedE2BConfig`.
+    def _resolve_template_id(self) -> str:
+        """Resolve a Harbor task name to its e2b template id."""
+        templates_path = self._config.get("templates_json") or os.environ.get("E2B_TEMPLATES_PATH")
+        if templates_path is None:
+            raise RuntimeError("E2B_TEMPLATES_PATH not set and no templates_path provided.")
+        templates = json.loads(Path(templates_path).read_text())
+        # Accept both Harbor's `<benchmark>/<task>` form and the bare dir name.
+        candidates = [self.task_id, self.task_id.split("/")[-1]]
+        for name in candidates:
+            if name in templates:
+                return templates[name]
+        raise KeyError(f"Task {self.task_id!r} has no matching template; tried: {candidates}.")
 
-        Applies the connection env vars the e2b SDK reads, resolves the template
-        id (explicit or via the templates map), and constructs the environment.
-        """
-        cls._apply_connection_env(config)
-        template_id = config.get("template_id") or cls.resolve_template_id(
-            task_name=task_id,
-            template_map_path=config.get("templates_json"),
-        )
-        return cls(
-            environment_dir=environment_dir,
-            environment_name=environment_name,
-            session_id=session_id,
-            trial_paths=trial_paths,
-            task_env_config=task_env_config,
-            template_id=template_id,
-        )
+    def _set_e2b_env_vars(self) -> None:
+        """Write `domain`/`api_key` into the env vars harbor's E2BEnvironment + SDK read."""
+        if domain := self._config.get("domain"):
+            os.environ["E2B_DOMAIN"] = domain
+        if api_key := self._config.get("api_key"):
+            os.environ["E2B_API_KEY"] = api_key
+        elif api_key_file := self._config.get("api_key_file"):
+            key = Path(api_key_file).expanduser().read_text().strip()
+            if not key:
+                raise ValueError(f"e2b api_key_file is empty: {api_key_file}")
+            os.environ["E2B_API_KEY"] = key
 
     @override
     async def start(self, force_build: bool) -> None:
@@ -114,86 +109,16 @@ class PrebakedE2BEnvironment(E2BEnvironment):
         # workdir. Self-guards to a no-op when not needed, so always safe.
         await self._upload_environment_dir_after_start()
 
-    @override
-    async def _create_template(self) -> None:  # type: ignore[override]
-        # Defensive: start() skips the build path, so this should be unreachable.
-        raise RuntimeError(
-            "PrebakedE2BEnvironment does not auto-build templates. "
-            "Templates must be baked against the e2b cluster before eval.",
-        )
 
-    @staticmethod
-    def _apply_connection_env(config: PrebakedE2BConfig) -> None:
-        """Write `domain`/`api_key` into the env vars harbor's E2BEnvironment + SDK read."""
-        if domain := config.get("domain"):
-            os.environ["E2B_DOMAIN"] = domain
-        if api_key := config.get("api_key"):
-            os.environ["E2B_API_KEY"] = api_key
-        elif api_key_file := config.get("api_key_file"):
-            key = Path(api_key_file).expanduser().read_text().strip()
-            if not key:
-                raise ValueError(f"e2b api_key_file is empty: {api_key_file}")
-            os.environ["E2B_API_KEY"] = key
+def validate_api_key(api_key: str) -> None:
+    """Validate an e2b API key by `e2b_` prefix + non-empty body only.
 
-    @staticmethod
-    def _permissive_validate_api_key(api_key: str) -> None:
-        """Validate an e2b API key by `e2b_` prefix + non-empty body only.
-
-        The SDK normally requires hex keys; self-hosted clusters mint `[a-z0-9]`
-        ones. Installed onto `e2b.api.validate_api_key` at import (bottom of file).
-        """
-        if not isinstance(api_key, str) or not api_key.startswith("e2b_") or len(api_key) <= 4:
-            raise AuthenticationException('Invalid API key format: expected "e2b_" followed by a non-empty body.')
-
-    @staticmethod
-    def _load_template_map(path: str | Path) -> dict[str, str]:
-        """Load a {task_name: template_id} mapping from a JSON file."""
-        p = Path(path)
-        if not p.exists():
-            raise FileNotFoundError(
-                f"Templates file not found at {p}. Bake the task templates against the e2b cluster first.",
-            )
-        data = json.loads(p.read_text())
-        if not isinstance(data, dict):
-            raise ValueError(f"{p} must contain a JSON object mapping task_name -> template_id.")
-        return data
-
-    @classmethod
-    def resolve_template_id(cls, task_name: str, template_map_path: str | Path | None = None) -> str:
-        """Resolve a Harbor task name to its e2b template id.
-
-        Args:
-            task_name: The task's name (e.g. `"fix-git"`), matching the dataset
-                directory and `Task.name` after Harbor's mapper has run.
-            template_map_path: Path to `templates.json`; falls back to
-                `E2B_TEMPLATES_PATH` when None.
-
-        Raises:
-            FileNotFoundError: If the templates file does not exist.
-            KeyError: If the task has no entry (its template isn't baked yet).
-        """
-        if template_map_path is None:
-            template_map_path = os.environ.get("E2B_TEMPLATES_PATH")
-        if template_map_path is None:
-            raise RuntimeError(
-                "E2B_TEMPLATES_PATH not set and no template_map_path provided. "
-                "Set it to a templates.json mapping task_name -> template_id.",
-            )
-        mapping = cls._load_template_map(template_map_path)
-        # Accept both Harbor's `<benchmark>/<task>` form and the bare dir name:
-        # the mapping is keyed by bare name; the evaluator passes the full Task.name.
-        candidates = [task_name, task_name.split("/")[-1]]
-        for candidate in candidates:
-            if candidate in mapping:
-                return mapping[candidate]
-        raise KeyError(
-            f"Task {task_name!r} has no template. "
-            f"Tried: {candidates}. "
-            f"Known tasks: {sorted(mapping.keys())[:10]}{'...' if len(mapping) > 10 else ''}. "
-            f"Bake the template for {candidates[-1]!r} first.",
-        )
+    The SDK normally requires hex keys; self-hosted clusters mint `[a-z0-9]`
+    ones. Installed onto `e2b.api.validate_api_key` at import (bottom of file).
+    """
+    if not isinstance(api_key, str) or not api_key.startswith("e2b_") or len(api_key) <= 4:
+        raise AuthenticationException('Invalid API key format: expected "e2b_" followed by a non-empty body.')
 
 
-# Relax the SDK's hex-only key check before any Sandbox is constructed; some
-# self-hosted clusters use a broader key alphabet. See `_permissive_validate_api_key`.
-_e2b_api.validate_api_key = PrebakedE2BEnvironment._permissive_validate_api_key
+# Relax the SDK's hex-only key check before any Sandbox is constructed; self-hosted clusters use a broader key alphabet.
+_e2b_api.validate_api_key = validate_api_key

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -37,7 +37,6 @@ from typing_extensions import NotRequired, TypedDict, Unpack, override
 
 from strands_env.core import Environment, ModelFactory
 from strands_env.core.environment import EnvironmentConfig
-from strands_env.core.types import RewardFunction
 
 from .reward import HarborReward
 
@@ -91,11 +90,10 @@ class HarborEnv(Environment):
         self,
         *,
         model_factory: ModelFactory,
-        reward_fn: RewardFunction | None = None,
         **config: Unpack[HarborConfig],
     ):
         """Initialize a `HarborEnv` instance."""
-        super().__init__(model_factory=model_factory, reward_fn=None, **config)  # type: ignore[misc]
+        super().__init__(model_factory=model_factory, **config)  # type: ignore[misc]
         self.task_id: str = str(self.config["task_id"])
         self.task_paths = TaskPaths(Path(str(self.config["task_dir"])))
         self.trial_paths = TrialPaths(Path(str(self.config["trial_dir"])))
@@ -103,19 +101,20 @@ class HarborEnv(Environment):
         self.backend: Literal["docker", "e2b"] = self.config.get("backend", "docker")
         self.task_env_config: TaskEnvironmentConfig = self.config.get("task_env_config", TaskEnvironmentConfig())
         self.prebaked_e2b_config: PrebakedE2BConfig = self.config.get("prebaked_e2b_config", {})
-        self.docker_env: HarborEnvironment | None = None
-        self.reward_fn = reward_fn or HarborReward(self)
+        self.sandbox: HarborEnvironment | None = None
+        # Harbor's reward is tied to the sandbox, so we don't need to pass it in.
+        self.reward_fn = HarborReward(self)
 
     @override
     async def reset(self) -> None:
-        """Build and start the container environment."""
+        """Build and start the sandbox."""
         self.trial_paths.mkdir()
         session_id = f"{self.task_id}-{uuid.uuid4().hex[:8]}"
 
         force_build = True
         match self.backend:
             case "docker":
-                self.docker_env = EnvironmentFactory.create_environment(
+                self.sandbox = EnvironmentFactory.create_environment(
                     type=EnvironmentType.DOCKER,
                     environment_dir=self.task_paths.environment_dir,
                     environment_name=session_id,
@@ -126,9 +125,11 @@ class HarborEnv(Environment):
             case "e2b":
                 from .e2b import PrebakedE2BEnvironment
 
-                self.docker_env = PrebakedE2BEnvironment.from_config(
-                    self.prebaked_e2b_config,
+                # we use prebaked e2b for self-hosting on e.g., AWS
+                self.sandbox = PrebakedE2BEnvironment(
                     task_id=self.task_id,
+                    prebaked_e2b_config=self.prebaked_e2b_config,
+                    # below are the same as harbor's E2BEnvironment
                     environment_dir=self.task_paths.environment_dir,
                     environment_name=session_id,
                     session_id=session_id,
@@ -138,7 +139,7 @@ class HarborEnv(Environment):
                 # Prebaked templates are static; force_build is a no-op here.
                 force_build = False
 
-        await self.docker_env.start(force_build=force_build)
+        await self.sandbox.start(force_build=force_build)
 
     @tool
     async def execute_command(self, command: str) -> str:
@@ -151,9 +152,9 @@ class HarborEnv(Environment):
             Command output (stdout + stderr combined).
         """
         # TODO: Align the terminal command ouput with OpenHand's output format.
-        if not self.docker_env:
-            raise RuntimeError("Docker environment not initialized")
-        result = await self.docker_env.exec(command, timeout_sec=self.timeout)
+        if not self.sandbox:
+            raise RuntimeError("Sandbox not initialized")
+        result = await self.sandbox.exec(command, timeout_sec=self.timeout)
         output = result.stdout or ""
         if result.stderr:
             output += f"\n[stderr]: {result.stderr}"
@@ -168,7 +169,7 @@ class HarborEnv(Environment):
 
     @override
     async def cleanup(self) -> None:
-        """Stop and delete the Docker environment."""
-        if self.docker_env:
-            await self.docker_env.stop(delete=True)
-            self.docker_env = None
+        """Stop and delete the sandbox."""
+        if self.sandbox:
+            await self.sandbox.stop(delete=True)
+            self.sandbox = None

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -47,23 +47,23 @@ class HarborReward(RewardFunction):
 
     async def _run_verification(self) -> float:
         """Upload tests, execute `test.sh`, download results, and parse reward."""
-        assert self._env.docker_env is not None, "Docker environment not initialized"
-        docker_env = self._env.docker_env
+        assert self._env.sandbox is not None, "Sandbox not initialized"
+        sandbox = self._env.sandbox
         task_paths = self._env.task_paths
         trial_paths = self._env.trial_paths
         timeout = self._env.timeout
 
         # Upload and run tests.
-        await docker_env.upload_dir(source_dir=task_paths.tests_dir, target_dir="/tests")
+        await sandbox.upload_dir(source_dir=task_paths.tests_dir, target_dir="/tests")
         test_cmd = (
             'export PATH="$HOME/.local/bin:$PATH" && '
             f"bash /tests/test.sh 2>&1 | tee {EnvironmentPaths.verifier_dir}/test-stdout.txt"
         )
-        await docker_env.exec(test_cmd, timeout_sec=timeout)
+        await sandbox.exec(test_cmd, timeout_sec=timeout)
 
         # Download results if not using mounted volumes
-        if not docker_env.capabilities.mounted:
-            await docker_env.download_dir(
+        if not sandbox.capabilities.mounted:
+            await sandbox.download_dir(
                 source_dir=str(EnvironmentPaths.verifier_dir),
                 target_dir=trial_paths.verifier_dir,
             )

--- a/tests/unit/environments/harbor/test_e2b.py
+++ b/tests/unit/environments/harbor/test_e2b.py
@@ -14,10 +14,10 @@
 
 """Unit tests for the Harbor `e2b` backend adapter (`e2b.py`).
 
-Covers the harbor-independent logic: template resolution, the templates.json
-loader, the permissive api-key validator, and the `PrebakedE2BEnvironment`
-overrides (build-skip + Harbor dir creation). Harbor's `E2BEnvironment` base and
-the e2b SDK are not exercised against a real cluster — sandbox creation is mocked.
+Covers the harbor-independent logic: template resolution, connection env-var
+export, the permissive api-key validator, and the `PrebakedE2BEnvironment`
+`__init__`/`start` overrides. Harbor's `E2BEnvironment` base and the e2b SDK are
+not exercised against a real cluster — sandbox creation is mocked.
 """
 
 from __future__ import annotations
@@ -39,14 +39,35 @@ from e2b.exceptions import AuthenticationException  # noqa: E402
 from strands_env.environments.harbor import e2b  # noqa: E402
 from strands_env.environments.harbor.e2b import PrebakedE2BEnvironment  # noqa: E402
 
-# The api-key validator and template-resolution helpers are static/class methods
-# on PrebakedE2BEnvironment; bind them as module-local names for readable tests.
-_permissive_validate_api_key = PrebakedE2BEnvironment._permissive_validate_api_key
-_load_template_map = PrebakedE2BEnvironment._load_template_map
-resolve_template_id = PrebakedE2BEnvironment.resolve_template_id
+#: `validate_api_key` is a module-level function; bind it for readable tests.
+validate_api_key = e2b.validate_api_key
+
+
+def _bare_env(*, task_id: str = "fix-git", config: dict | None = None) -> PrebakedE2BEnvironment:
+    """A `PrebakedE2BEnvironment` with only `task_id`/`_config` set, bypassing __init__.
+
+    `_resolve_template_id` and `_set_e2b_env_vars` are private instance methods
+    that read only those two attributes, so this drives them in isolation without
+    touching the e2b SDK or harbor's base `__init__`.
+    """
+    env = PrebakedE2BEnvironment.__new__(PrebakedE2BEnvironment)
+    env.task_id = task_id
+    env._config = config or {}
+    return env
+
+
+def _resolve_template_id(task_id: str, config: dict) -> str:
+    """Drive `_resolve_template_id` on a bare instance."""
+    return _bare_env(task_id=task_id, config=config)._resolve_template_id()
+
+
+def _set_e2b_env_vars(config: dict) -> None:
+    """Drive `_set_e2b_env_vars` on a bare instance."""
+    _bare_env(config=config)._set_e2b_env_vars()
+
 
 # ---------------------------------------------------------------------------
-# _permissive_validate_api_key
+# validate_api_key
 # ---------------------------------------------------------------------------
 
 
@@ -55,30 +76,30 @@ class TestPermissiveValidateApiKey:
 
     def test_accepts_hex_key(self):
         """A standard hex key passes (no-op for upstream keys)."""
-        _permissive_validate_api_key("e2b_0123456789abcdef")  # no raise
+        validate_api_key("e2b_0123456789abcdef")  # no raise
 
     def test_accepts_non_hex_alnum_key(self):
         """A self-hosted `[a-z0-9]` key passes (the reason the patch exists)."""
-        _permissive_validate_api_key("e2b_3fw7jq32e71yfqu0")  # no raise
+        validate_api_key("e2b_3fw7jq32e71yfqu0")  # no raise
 
     def test_rejects_missing_prefix(self):
         """A key without the `e2b_` prefix is rejected."""
         with pytest.raises(AuthenticationException):
-            _permissive_validate_api_key("sk_0123456789")
+            validate_api_key("sk_0123456789")
 
     def test_rejects_empty_body(self):
         """`e2b_` with no body (len <= 4) is rejected."""
         with pytest.raises(AuthenticationException):
-            _permissive_validate_api_key("e2b_")
+            validate_api_key("e2b_")
 
     def test_rejects_non_string(self):
         """A non-string key is rejected, not crashed on."""
         with pytest.raises(AuthenticationException):
-            _permissive_validate_api_key(None)  # type: ignore[arg-type]
+            validate_api_key(None)  # type: ignore[arg-type]
 
     def test_patch_is_installed_on_e2b_sdk(self):
         """Importing the module installs the validator on e2b.api at module load."""
-        assert _e2b_api_validator() is _permissive_validate_api_key
+        assert _e2b_api_validator() is validate_api_key
 
 
 def _e2b_api_validator():
@@ -88,45 +109,12 @@ def _e2b_api_validator():
 
 
 # ---------------------------------------------------------------------------
-# _load_template_map
-# ---------------------------------------------------------------------------
-
-
-class TestLoadTemplateMap:
-    """Loading + validating a templates.json file."""
-
-    def test_loads_valid_mapping(self, tmp_path: Path):
-        """A JSON object is returned as a dict."""
-        p = tmp_path / "templates.json"
-        p.write_text(json.dumps({"fix-git": "tmpl-abc", "make-doc": "tmpl-def"}))
-        assert _load_template_map(p) == {"fix-git": "tmpl-abc", "make-doc": "tmpl-def"}
-
-    def test_missing_file_raises_filenotfound(self, tmp_path: Path):
-        """A nonexistent path raises FileNotFoundError with guidance."""
-        with pytest.raises(FileNotFoundError, match="Templates file not found"):
-            _load_template_map(tmp_path / "nope.json")
-
-    def test_non_dict_json_raises_valueerror(self, tmp_path: Path):
-        """A JSON array (or any non-object) raises a clear ValueError."""
-        p = tmp_path / "bad.json"
-        p.write_text(json.dumps(["fix-git", "make-doc"]))
-        with pytest.raises(ValueError, match="must contain a JSON object"):
-            _load_template_map(p)
-
-    def test_accepts_str_path(self, tmp_path: Path):
-        """A str path (not just Path) works."""
-        p = tmp_path / "templates.json"
-        p.write_text(json.dumps({"t": "id"}))
-        assert _load_template_map(str(p)) == {"t": "id"}
-
-
-# ---------------------------------------------------------------------------
-# resolve_template_id
+# _resolve_template_id
 # ---------------------------------------------------------------------------
 
 
 class TestResolveTemplateId:
-    """Resolving a task name to its template id."""
+    """Resolving a task name to its template id (`_resolve_template_id`)."""
 
     @pytest.fixture
     def templates(self, tmp_path: Path) -> Path:
@@ -136,39 +124,80 @@ class TestResolveTemplateId:
 
     def test_direct_name_hit(self, templates: Path):
         """A bare task name resolves directly."""
-        assert resolve_template_id("fix-git", templates) == "tmpl-fixgit"
+        assert _resolve_template_id("fix-git", {"templates_json": str(templates)}) == "tmpl-fixgit"
 
     def test_benchmark_prefixed_name_falls_back_to_bare(self, templates: Path):
         """Harbor's `<benchmark>/<task>` form falls back to the bare dir name."""
-        assert resolve_template_id("terminal-bench/fix-git", templates) == "tmpl-fixgit"
+        assert _resolve_template_id("terminal-bench/fix-git", {"templates_json": str(templates)}) == "tmpl-fixgit"
 
-    def test_reads_env_var_when_path_is_none(self, templates: Path, monkeypatch):
-        """With no explicit path, E2B_TEMPLATES_PATH is used."""
+    def test_reads_env_var_when_config_has_no_path(self, templates: Path, monkeypatch):
+        """With no `templates_json` in config, E2B_TEMPLATES_PATH is used."""
         monkeypatch.setenv("E2B_TEMPLATES_PATH", str(templates))
-        assert resolve_template_id("make-doc") == "tmpl-makedoc"
+        assert _resolve_template_id("make-doc", {}) == "tmpl-makedoc"
 
     def test_missing_env_var_and_path_raises_runtimeerror(self, monkeypatch):
-        """No path + unset env var raises an actionable RuntimeError."""
+        """No `templates_json` + unset env var raises an actionable RuntimeError."""
         monkeypatch.delenv("E2B_TEMPLATES_PATH", raising=False)
         with pytest.raises(RuntimeError, match="E2B_TEMPLATES_PATH not set"):
-            resolve_template_id("fix-git")
+            _resolve_template_id("fix-git", {})
 
     def test_unknown_task_raises_keyerror(self, templates: Path):
         """A task absent from the mapping raises KeyError listing what was tried."""
-        with pytest.raises(KeyError, match="has no template"):
-            resolve_template_id("never-baked", templates)
+        with pytest.raises(KeyError, match="has no matching template"):
+            _resolve_template_id("never-baked", {"templates_json": str(templates)})
 
-    def test_explicit_path_overrides_env_var(self, templates: Path, tmp_path: Path, monkeypatch):
-        """An explicit template_map_path wins over E2B_TEMPLATES_PATH."""
+    def test_missing_file_raises_filenotfound(self, tmp_path: Path):
+        """A nonexistent templates path surfaces FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            _resolve_template_id("fix-git", {"templates_json": str(tmp_path / "nope.json")})
+
+    def test_config_path_overrides_env_var(self, templates: Path, tmp_path: Path, monkeypatch):
+        """A `templates_json` in config wins over E2B_TEMPLATES_PATH."""
         other = tmp_path / "other.json"
         other.write_text(json.dumps({"fix-git": "from-env-var"}))
         monkeypatch.setenv("E2B_TEMPLATES_PATH", str(other))
-        # explicit `templates` maps fix-git -> tmpl-fixgit, not from-env-var
-        assert resolve_template_id("fix-git", templates) == "tmpl-fixgit"
+        assert _resolve_template_id("fix-git", {"templates_json": str(templates)}) == "tmpl-fixgit"
 
 
 # ---------------------------------------------------------------------------
-# PrebakedE2BEnvironment
+# PrebakedE2BEnvironment.__init__
+# ---------------------------------------------------------------------------
+
+
+class TestPrebakedE2BEnvironmentInit:
+    """__init__: resolve the pinned template id + export connection env vars."""
+
+    def test_explicit_template_id_skips_resolution(self):
+        """An explicit `template_id` is used directly and the connection env is exported."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(e2b.E2BEnvironment, "__init__", return_value=None) as base_init,
+        ):
+            env = PrebakedE2BEnvironment(
+                task_id="fix-git",
+                prebaked_e2b_config={"template_id": "tmpl-explicit", "domain": "e2b.acme.dev"},
+            )
+            assert env._template_id == "tmpl-explicit"
+            assert os.environ["E2B_DOMAIN"] == "e2b.acme.dev"
+        base_init.assert_called_once()
+
+    def test_resolves_template_from_map(self, tmp_path: Path):
+        """With no `template_id`, the id is resolved from `templates_json` by task name."""
+        templates = tmp_path / "templates.json"
+        templates.write_text(json.dumps({"fix-git": "tmpl-resolved"}))
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(e2b.E2BEnvironment, "__init__", return_value=None),
+        ):
+            env = PrebakedE2BEnvironment(
+                task_id="fix-git",
+                prebaked_e2b_config={"templates_json": str(templates)},
+            )
+        assert env._template_id == "tmpl-resolved"
+
+
+# ---------------------------------------------------------------------------
+# PrebakedE2BEnvironment.start
 # ---------------------------------------------------------------------------
 
 
@@ -184,24 +213,6 @@ def _make_env() -> PrebakedE2BEnvironment:
     env._sandbox = MagicMock()
     env.logger = MagicMock()
     return env
-
-
-class TestPrebakedE2BEnvironmentConstruction:
-    """Constructor + class-level attributes."""
-
-    def test_init_stores_template_id(self):
-        """The `template_id` kwarg is recorded as `_template_id`."""
-        with patch.object(e2b.E2BEnvironment, "__init__", return_value=None) as base_init:
-            env = PrebakedE2BEnvironment(
-                Path("/env"),
-                "env-name",
-                "sess-1",
-                MagicMock(),  # trial_paths
-                MagicMock(),  # task_env_config
-                template_id="tmpl-xyz",
-            )
-        assert env._template_id == "tmpl-xyz"
-        base_init.assert_called_once()
 
 
 class TestPrebakedE2BEnvironmentStart:
@@ -250,25 +261,19 @@ class TestPrebakedE2BEnvironmentStart:
         with pytest.raises(RuntimeError, match="Sandbox not found"):
             await env.start(force_build=False)
 
-    async def test_create_template_raises(self):
-        """The auto-build path is disabled and raises a precise error."""
-        env = _make_env()
-        with pytest.raises(RuntimeError, match="does not auto-build templates"):
-            await env._create_template()
-
 
 # ---------------------------------------------------------------------------
-# PrebakedE2BEnvironment._apply_connection_env
+# _set_e2b_env_vars
 # ---------------------------------------------------------------------------
 
 
-class TestApplyConnectionEnv:
+class TestSetE2BEnvVars:
     """Writing the e2b connection (domain/api_key) into the env vars the SDK reads."""
 
     def test_sets_domain_and_api_key(self):
         """`domain`/`api_key` land in E2B_DOMAIN/E2B_API_KEY."""
         with patch.dict(os.environ, {}, clear=True):
-            PrebakedE2BEnvironment._apply_connection_env({"domain": "e2b.acme.dev", "api_key": "e2b_abc"})
+            _set_e2b_env_vars({"domain": "e2b.acme.dev", "api_key": "e2b_abc"})
             assert os.environ["E2B_DOMAIN"] == "e2b.acme.dev"
             assert os.environ["E2B_API_KEY"] == "e2b_abc"
 
@@ -277,7 +282,7 @@ class TestApplyConnectionEnv:
         key_file = tmp_path / "key"
         key_file.write_text("  e2b_fromfile\n")
         with patch.dict(os.environ, {}, clear=True):
-            PrebakedE2BEnvironment._apply_connection_env({"api_key_file": str(key_file)})
+            _set_e2b_env_vars({"api_key_file": str(key_file)})
             assert os.environ["E2B_API_KEY"] == "e2b_fromfile"
 
     def test_api_key_wins_over_api_key_file(self, tmp_path: Path):
@@ -285,7 +290,7 @@ class TestApplyConnectionEnv:
         key_file = tmp_path / "key"
         key_file.write_text("e2b_fromfile")
         with patch.dict(os.environ, {}, clear=True):
-            PrebakedE2BEnvironment._apply_connection_env({"api_key": "e2b_inline", "api_key_file": str(key_file)})
+            _set_e2b_env_vars({"api_key": "e2b_inline", "api_key_file": str(key_file)})
             assert os.environ["E2B_API_KEY"] == "e2b_inline"
 
     def test_empty_api_key_file_raises(self, tmp_path: Path):
@@ -296,58 +301,11 @@ class TestApplyConnectionEnv:
             patch.dict(os.environ, {}, clear=True),
             pytest.raises(ValueError, match="api_key_file is empty"),
         ):
-            PrebakedE2BEnvironment._apply_connection_env({"api_key_file": str(key_file)})
+            _set_e2b_env_vars({"api_key_file": str(key_file)})
 
     def test_empty_config_is_noop(self):
         """An empty config writes nothing."""
         with patch.dict(os.environ, {}, clear=True):
-            PrebakedE2BEnvironment._apply_connection_env({})
+            _set_e2b_env_vars({})
             assert "E2B_DOMAIN" not in os.environ
             assert "E2B_API_KEY" not in os.environ
-
-
-# ---------------------------------------------------------------------------
-# PrebakedE2BEnvironment.from_config
-# ---------------------------------------------------------------------------
-
-
-class TestFromConfig:
-    """The factory: apply connection env, resolve template id, construct."""
-
-    @staticmethod
-    def _build_kwargs() -> dict:
-        return {
-            "task_id": "fix-git",
-            "environment_dir": Path("/env"),
-            "environment_name": "env-name",
-            "session_id": "sess-1",
-            "trial_paths": MagicMock(),
-            "task_env_config": MagicMock(),
-        }
-
-    def test_explicit_template_id_skips_resolution(self):
-        """An explicit `template_id` is used directly and the connection env is applied."""
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            patch.object(e2b.E2BEnvironment, "__init__", return_value=None),
-        ):
-            env = PrebakedE2BEnvironment.from_config(
-                {"template_id": "tmpl-explicit", "domain": "e2b.acme.dev"},
-                **self._build_kwargs(),
-            )
-            assert env._template_id == "tmpl-explicit"
-            assert os.environ["E2B_DOMAIN"] == "e2b.acme.dev"
-
-    def test_resolves_template_from_map(self, tmp_path: Path):
-        """With no `template_id`, the id is resolved from `templates_json` by task name."""
-        templates = tmp_path / "templates.json"
-        templates.write_text(json.dumps({"fix-git": "tmpl-resolved"}))
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            patch.object(e2b.E2BEnvironment, "__init__", return_value=None),
-        ):
-            env = PrebakedE2BEnvironment.from_config(
-                {"templates_json": str(templates)},
-                **self._build_kwargs(),
-            )
-        assert env._template_id == "tmpl-resolved"


### PR DESCRIPTION
## Summary

A cohesion/clarity pass over the Harbor environment. No behavior change for the docker backend; behavior-preserving for the e2b backend.

### `env.py`
- **Rename `docker_env` → `sandbox`.** The attribute holds either a Docker `DockerEnvironment` or a `PrebakedE2BEnvironment`, so the "docker" name was misleading. `backend` (the `"docker"`/`"e2b"` string) and `sandbox` (the live instance) now pair cleanly.
- **Drop the `reward_fn` `__init__` param.** A Harbor task *defines* its own success criterion (`tests/test.sh` → `reward.txt`), so the reward is the task contract, not a policy knob — and no caller ever passed one. `self.reward_fn = HarborReward(self)`, removing the `reward_fn=None` → `or HarborReward(self)` dance.

### `e2b.py`
- **`_permissive_validate_api_key` → module-level `validate_api_key`.** It patches the e2b SDK at import; it was never environment behavior.
- **Fold `from_config` into `__init__`** (`task_id`, `prebaked_e2b_config`, …); `_resolve_template_id` / `_set_e2b_env_vars` become private instance methods.
- **Simplify template resolution:** a clear `RuntimeError` when no path resolves, `FileNotFoundError`/`JSONDecodeError` surface as themselves, trimmed `KeyError`.
- **Remove the unreachable `_create_template` override** — `start()` fully overrides the only base path that called it.
- **Rename `_apply_connection_env` → `_set_e2b_env_vars`**; drop now-unused `TYPE_CHECKING` imports.

### Tests
- `test_e2b.py` reworked to match: the now-private instance methods are driven via a bare-instance helper, and the `from_config`/construction cases are folded into `__init__` tests.

## Checks
- ✅ `ruff check` + `ruff format --check` (src/tests/examples)
- ✅ `mypy src/strands_env` — 58 files clean
- ✅ `pytest tests/unit/` — 204 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)