### PR TITLE
feat(eval): onboard terminal-bench-2.1 and unify Harbor benchmark config vars

### DIFF
--- a/src/strands_env/eval/benchmarks/swebench.py
+++ b/src/strands_env/eval/benchmarks/swebench.py
@@ -15,7 +15,7 @@
 """Evaluator for SWE-bench Verified (Harbor format).
 
 The Harbor-format SWE-bench Verified tasks live as a subdirectory inside
-the larger ``harbor-datasets.git`` repo. We sparse-checkout just that
+the larger `harbor-datasets.git` repo. We sparse-checkout just that
 subdirectory at a pinned commit so we don't have to clone every benchmark.
 """
 
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import ClassVar
 
 from typing_extensions import override
 
@@ -44,12 +43,10 @@ class SWEBenchVerifiedEvaluator(TerminalBenchEvaluator):
     """
 
     benchmark_name = "swebench-verified"
-    GIT_URL = "https://github.com/laude-institute/harbor-datasets.git"
-    GIT_COMMIT = "0d48cdd78e14a1e22afa09abcfc1bf210427d66f"
-    SUBDIR = "datasets/swebench-verified"
-    data_dir: Path = Path("./data/swebench-verified")
-    #: SWE-bench-tuned system prompt injected into each task's config (shipped with `HarborEnv`).
-    system_prompt_path: ClassVar[Path | None] = SWE_SYSTEM_PROMPT_PATH
+    git_url = "https://github.com/laude-institute/harbor-datasets.git"
+    git_commit = "0d48cdd78e14a1e22afa09abcfc1bf210427d66f"
+    git_subdir = "datasets/swebench-verified"
+    system_prompt_path: Path | None = SWE_SYSTEM_PROMPT_PATH
 
     @override
     def _download_dataset(self) -> None:
@@ -80,7 +77,7 @@ class SWEBenchVerifiedEvaluator(TerminalBenchEvaluator):
                 "1",
                 "--branch",
                 "main",
-                self.GIT_URL,
+                self.git_url,
                 str(repo_dir),
             ],
             check=True,
@@ -90,15 +87,15 @@ class SWEBenchVerifiedEvaluator(TerminalBenchEvaluator):
             check=True,
         )
         subprocess.run(
-            ["git", "-C", str(repo_dir), "sparse-checkout", "set", self.SUBDIR],
+            ["git", "-C", str(repo_dir), "sparse-checkout", "set", self.git_subdir],
             check=True,
         )
         subprocess.run(
-            ["git", "-C", str(repo_dir), "checkout", self.GIT_COMMIT],
+            ["git", "-C", str(repo_dir), "checkout", self.git_commit],
             check=True,
         )
 
-        sub = repo_dir / self.SUBDIR
+        sub = repo_dir / self.git_subdir
         if not sub.is_dir():
             raise RuntimeError(f"sparse checkout missing {sub}")
         sub.rename(self.data_dir)

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import ClassVar
 
 from harbor.models.task.task import Task
 from typing_extensions import override
@@ -41,16 +40,21 @@ class TerminalBenchTaskContext(TaskContext):
 class TerminalBenchEvaluator(Evaluator):
     """Base evaluator for Harbor-format benchmarks (loads a directory of task subdirs)."""
 
-    GIT_URL: str = ""
-    data_dir: Path = Path("./data/terminal-bench")
-    #: Optional benchmark-specific system prompt injected into each task's config.
-    system_prompt_path: ClassVar[Path | None] = None
+    benchmark_name: str = "terminal-bench"
+    git_url: str = ""
+    tasks_subdir: str = "."  # subdirectory within `data_dir` if any
+    system_prompt_path: Path | None = None  # optional benchmark-specific system prompt
+
+    @property
+    def data_dir(self) -> Path:
+        """Local directory the dataset is downloaded into (`./data/<benchmark_name>`)."""
+        return Path("data") / self.benchmark_name
 
     def _download_dataset(self) -> None:
         """Download Terminal-Bench tasks from Git repository."""
         self.data_dir.parent.mkdir(parents=True, exist_ok=True)
         subprocess.run(
-            ["git", "clone", "--depth", "1", self.GIT_URL, str(self.data_dir)],
+            ["git", "clone", "--depth", "1", self.git_url, str(self.data_dir)],
             check=True,
         )
 
@@ -61,7 +65,7 @@ class TerminalBenchEvaluator(Evaluator):
             self._download_dataset()
 
         actions = []
-        for task_dir in sorted(self.data_dir.iterdir()):
+        for task_dir in sorted((self.data_dir / self.tasks_subdir).iterdir()):
             if task_dir.is_dir() and not task_dir.name.startswith("."):
                 actions.append(self._load_single_task(task_dir))
         return actions
@@ -111,13 +115,25 @@ class TerminalBenchEvaluator(Evaluator):
         return sample
 
 
+@register_eval("terminal-bench-2.1")
+class TerminalBench21Evaluator(TerminalBenchEvaluator):
+    """Evaluator for Terminal-Bench-2.1 benchmark.
+
+    The upstream repo nests its 89 Harbor-format tasks under a `tasks/` directory (alongside a
+    `configs/` folder of leaderboard agent configs), so the task root differs from Terminal-Bench-2.
+    """
+
+    benchmark_name = "terminal-bench-2.1"
+    git_url = "https://github.com/harbor-framework/terminal-bench-2-1.git"
+    tasks_subdir = "tasks"
+
+
 @register_eval("terminal-bench-2")
 class TerminalBench2Evaluator(TerminalBenchEvaluator):
     """Evaluator for Terminal-Bench-2 benchmark."""
 
     benchmark_name = "terminal-bench-2"
-    GIT_URL = "https://github.com/laude-institute/terminal-bench-2.git"
-    data_dir: Path = Path("./data/terminal-bench-2")
+    git_url = "https://github.com/laude-institute/terminal-bench-2.git"
 
 
 @register_eval("terminal-bench-1")
@@ -125,8 +141,7 @@ class TerminalBench1Evaluator(TerminalBenchEvaluator):
     """Evaluator for Terminal-Bench-1 benchmark (migrated to Harbor format)."""
 
     benchmark_name = "terminal-bench-1"
-    GIT_URL = "https://github.com/laude-institute/terminal-bench.git"
-    data_dir: Path = Path("./data/terminal-bench-1")
+    git_url = "https://github.com/laude-institute/terminal-bench.git"
 
     def _rename_solution_yaml_files(self, tasks_dir: Path) -> None:
         """Rename solution.yaml files to allow all tasks to be mapped successfully."""

--- a/tests/unit/eval/test_terminal_bench.py
+++ b/tests/unit/eval/test_terminal_bench.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Terminal-Bench (Harbor) evaluators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("harbor", reason="harbor>=0.13.2 required to import the terminal_bench benchmark module")
+
+from strands_env.eval import get_benchmark, list_benchmarks  # noqa: E402
+from strands_env.eval.benchmarks.terminal_bench import TerminalBench21Evaluator  # noqa: E402
+
+
+def test_terminal_bench_variants_registered():
+    """All three Terminal-Bench variants are registered for discovery."""
+    benchmarks = list_benchmarks()
+    assert {"terminal-bench-1", "terminal-bench-2", "terminal-bench-2.1"} <= set(benchmarks)
+    assert get_benchmark("terminal-bench-2.1") is TerminalBench21Evaluator
+
+
+def test_terminal_bench_21_attributes():
+    """Terminal-Bench-2.1 points at the upstream repo and nests tasks under `tasks/`."""
+    assert TerminalBench21Evaluator.git_url == "https://github.com/harbor-framework/terminal-bench-2-1.git"
+    assert TerminalBench21Evaluator.tasks_subdir == "tasks"
+
+
+def test_data_dir_derived_from_benchmark_name(tmp_path: Path):
+    """`data_dir` is derived from `benchmark_name` as `./data/<benchmark_name>`."""
+    evaluator = TerminalBench21Evaluator(env_factory=lambda: None, output_path=tmp_path / "results.jsonl")
+    assert evaluator.data_dir == Path("data") / "terminal-bench-2.1"
+
+
+def test_terminal_bench_21_scans_tasks_subdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """`load_dataset` scans `data_dir/tasks`, skipping the sibling `configs/` dir and dotfiles."""
+    (tmp_path / "tasks" / "alpha").mkdir(parents=True)
+    (tmp_path / "tasks" / "beta").mkdir()
+    (tmp_path / "tasks" / ".hidden").mkdir()  # dotfiles are skipped
+    (tmp_path / "configs").mkdir()  # leaderboard configs live outside tasks/ and must be ignored
+
+    # data_dir is a read-only derived property; shadow it on the class to point at the fixture.
+    monkeypatch.setattr(TerminalBench21Evaluator, "data_dir", tmp_path)  # exists, so no download
+    evaluator = TerminalBench21Evaluator(env_factory=lambda: None, output_path=tmp_path / "out" / "results.jsonl")
+    monkeypatch.setattr(evaluator, "_load_single_task", lambda task_dir: task_dir.name)
+
+    assert evaluator.load_dataset() == ["alpha", "beta"]


### PR DESCRIPTION
## Summary

Onboards the **terminal-bench-2.1** benchmark and unifies the class-var conventions across the Harbor-format evaluators (`terminal-bench-*`, `swebench-verified`).

### Onboarding
- Adds `TerminalBench21Evaluator`, registered as `terminal-bench-2.1`, cloning [`harbor-framework/terminal-bench-2-1`](https://github.com/harbor-framework/terminal-bench-2-1).
- That repo nests its 89 Harbor tasks under a `tasks/` directory (alongside a `configs/` leaderboard dir), unlike `terminal-bench-2` which keeps tasks at the repo root. To handle this, the base `TerminalBenchEvaluator` gains a `tasks_subdir` knob (default `.`) controlling which subdirectory of `data_dir` is scanned for tasks.

### Refactor / cleanup
- Normalizes the Harbor-family class vars to lowercase snake_case with plain annotations: `GIT_URL`→`git_url`, `GIT_COMMIT`→`git_commit`, `SUBDIR`→`git_subdir`; drops the inconsistent `ClassVar` wrappers so the style matches every other benchmark (`benchmark_name: str`, `dataset_path: str`, …).
- Derives `data_dir` from `benchmark_name` via a read-only property (`./data/<benchmark_name>`), so subclasses no longer repeat it.

## Testing
- `ruff check` / `ruff format --check` / `mypy src/strands_env` — clean.
- `pytest tests/unit/` — 208 passed (includes new `tests/unit/eval/test_terminal_bench.py`, guarded by `pytest.importorskip("harbor")`).
- End-to-end load verification (with `harbor` installed): all 22 benchmarks import & register, all evaluators instantiate, and real `load_dataset()` succeeds for all four Harbor benchmarks — `terminal-bench-1` (migrated `.harbor/`), `terminal-bench-2` (root), `terminal-bench-2.1` (`tasks/`), `swebench-verified` (root). swebench's `_download_dataset` wiring verified to pass `git_url`/`git_subdir`/`git_commit` through to the git invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
