### PR TITLE
refactor(agent-world-model): fold _run_verification into the reward class

### DIFF
--- a/src/strands_env/environments/agent_world_model/reward.py
+++ b/src/strands_env/environments/agent_world_model/reward.py
@@ -35,19 +35,19 @@ OUTCOME_AGENT_FAILED = "AGENT_FAILED"
 OUTCOME_VERIFY_ERROR = "VERIFY_ERROR"
 
 
-def _run_verification(verify_code: str, initial_db_path: str, work_db_path: str, final_answer: str) -> dict:
-    """Execute verification code in a thread (blocking exec + SQLite I/O)."""
-    namespace: dict = {"sqlite3": sqlite3, "json": json}
-    exec(verify_code, namespace)  # noqa: S102
-    return namespace["verify_task_completion"](
-        initial_db_path=initial_db_path,
-        final_db_path=work_db_path,
-        final_answer=final_answer,
-    )
-
-
 class AgentWorldModelRewardFunction(RewardFunction):
     """Binary reward via execution-based verification."""
+
+    @staticmethod
+    def _run_verification(verify_code: str, initial_db_path: str, work_db_path: str, final_answer: str) -> dict:
+        """Execute verification code in a thread (blocking exec + SQLite I/O)."""
+        namespace: dict = {"sqlite3": sqlite3, "json": json}
+        exec(verify_code, namespace)  # noqa: S102
+        return namespace["verify_task_completion"](
+            initial_db_path=initial_db_path,
+            final_db_path=work_db_path,
+            final_answer=final_answer,
+        )
 
     async def compute(self, action: Action, step_result: StepResult) -> RewardResult:
         """Run verification code against the agent's final response."""
@@ -56,7 +56,7 @@ class AgentWorldModelRewardFunction(RewardFunction):
 
         try:
             result = await asyncio.to_thread(
-                _run_verification,
+                self._run_verification,
                 ctx.verify_code,
                 ctx.initial_db_path,
                 ctx.work_db_path,


### PR DESCRIPTION
## Summary

Small refactor in the `agent_world_model` reward: move the module-level `_run_verification` helper into `AgentWorldModelRewardFunction` as a `@staticmethod`, since it's only used by that class. The call site in `compute` now uses `self._run_verification`.

Pure encapsulation — no behavior change.

## Testing
- `ruff check` / `ruff format --check` / `mypy src/strands_env` — clean.
- `pytest tests/unit/` — 208 passed.

(The module itself requires the `agent-world-model` extra, which is py>=3.12-only and not part of the standard dev/CI install, so it isn't import-exercised in unit tests — but the change is a pure helper relocation with no import or logic changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
