### PR TITLE
feat(mcp-atlas): cache /list-tools across episodes and close http client on completion

### DIFF
--- a/examples/eval/mcp_atlas/env.py
+++ b/examples/eval/mcp_atlas/env.py
@@ -39,13 +39,7 @@ def create_env_factory(model_config: dict, **env_config):
     max_judge_retries = env_config.get("max_judge_retries", 3)
 
     docker_url = env_config.get("docker_url", MCPAtlasEnvironment.DEFAULT_DOCKER_URL)
-    http_client: httpx.AsyncClient | None = None
-
-    def _get_client() -> httpx.AsyncClient:
-        nonlocal http_client
-        if http_client is None or http_client.is_closed:
-            http_client = MCPAtlasEnvironment.create_client(base_url=docker_url)
-        return http_client
+    http_client = MCPAtlasEnvironment.create_client(base_url=docker_url)
 
     async def env_factory(action):
         ctx = action.task_context
@@ -54,10 +48,11 @@ def create_env_factory(model_config: dict, **env_config):
         reward_fn = MCPAtlasRewardFunction(judge_model=judge_models, max_model_retries=max_judge_retries)
         return MCPAtlasEnvironment(
             model_factory=model_factory,
-            http_client=_get_client(),
+            http_client=http_client,
             reward_fn=reward_fn,
             enabled_tools=ctx.enabled_tools,
             **env_config,
         )
 
+    env_factory.http_client = http_client  # type: ignore[attr-defined]
     return env_factory

--- a/src/strands_env/environments/mcp_atlas/env.py
+++ b/src/strands_env/environments/mcp_atlas/env.py
@@ -60,6 +60,7 @@ class MCPAtlasEnvironment(Environment):
         model_factory: ModelFactory,
         http_client: httpx.AsyncClient,
         reward_fn: RewardFunction | None = None,
+        cached_tools: list[dict] | None = None,
         **config: Unpack[MCPAtlasConfig],
     ):
         """Initialize a `MCPAtlasEnvironment` instance."""
@@ -69,6 +70,7 @@ class MCPAtlasEnvironment(Environment):
             **config,  # type: ignore[misc]
         )
         self._http_client = http_client
+        self._cached_tools = cached_tools
         self._tools: list[MCPAtlasTool] = []
         self._tool_timeout: int = int(self.config.get("tool_timeout", 60))
         enabled = self.config.get("enabled_tools")
@@ -99,13 +101,14 @@ class MCPAtlasEnvironment(Environment):
 
     @override
     async def reset(self) -> None:
-        """Fetch tools from the container and apply per-task filter."""
-        response = await self._http_client.post("/list-tools", timeout=self._tool_timeout)
-        response.raise_for_status()
-        all_tools = response.json()
+        """Fetch tools from the container (or use cache) and apply per-task filter."""
+        if self._cached_tools is None:
+            response = await self._http_client.post("/list-tools", timeout=self._tool_timeout)
+            response.raise_for_status()
+            self._cached_tools = response.json()
         self._tools = [
             MCPAtlasTool(MCPToolDef.model_validate(tool), self._http_client, timeout=self._tool_timeout)
-            for tool in all_tools
+            for tool in self._cached_tools
             if self._enabled_tools is None or tool["name"] in self._enabled_tools
         ]
         logger.info("MCP-Atlas: %d tools enabled", len(self._tools))

--- a/src/strands_env/eval/benchmarks/mcp_atlas.py
+++ b/src/strands_env/eval/benchmarks/mcp_atlas.py
@@ -89,6 +89,16 @@ class MCPAtlasEvaluator(Evaluator):
         self._available_servers = available_servers
 
     @override
+    async def run(self, actions: Iterable[Action]) -> dict[str, list[EvalSample]]:
+        """Run evaluation, closing any shared HTTP client at the end."""
+        try:
+            return await super().run(actions)
+        finally:
+            http_client = getattr(self.env_factory, "http_client", None)
+            if http_client is not None:
+                await http_client.aclose()
+
+    @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples where reward is missing or judge failed, so they are retried on resume."""
         reward = sample.step_result.reward


### PR DESCRIPTION
## Summary

Two small mcp_atlas improvements from running the benchmark at scale:

1. Cache `/list-tools` on `MCPAtlasEnvironment` so it's only fetched once per container instead of every reset.
2. Close the shared `httpx.AsyncClient` on evaluator completion instead of leaving it to GC.

## Changes

- **`environments/mcp_atlas/env.py`**: add `cached_tools` param; `reset()` reuses cached list when present, otherwise fetches and caches it. `enabled_tools` filtering still runs per task.
- **`examples/eval/mcp_atlas/env.py`**: drop the lazy `_get_client()` reopen-on-closed pattern; create the client eagerly and expose it as `env_factory.http_client`.
- **`eval/benchmarks/mcp_atlas.py`**: `MCPAtlasEvaluator.run()` overrides parent to `aclose()` the client from `env_factory.http_client` in a `finally` block.

## Verification

Ran the MCP-Atlas eval end-to-end. Both features work well.
