### PR TITLE
feat(tau2-bench): add Tau2BenchEnv environment

### DIFF
--- a/src/strands_env/environments/tau2_bench/README.md
+++ b/src/strands_env/environments/tau2_bench/README.md
@@ -1,0 +1,78 @@
+# tau2-bench Environment
+
+`Tau2BenchEnv` runs a [tau2-bench](https://github.com/sierra-research/tau2-bench) (Sierra Research) customer-service task: a multi-turn dialogue between the **agent under test** and an LLM **user-simulator**, both acting on a shared in-memory domain DB. The entire episode runs inside a single `agent.invoke_async()`, driven turn-by-turn by `Tau2BenchUserSimHook` via `AfterInvocationEvent.resume`. Termination is decided by stop markers in either side's reply (`###STOP###`, `###TRANSFER###`, `###OUT-OF-SCOPE###`) or a `max_turns` cap.
+
+## Domains
+
+| Domain | Tasks | Notes |
+|---|---|---|
+| `airline` | 50 | Agent tools only |
+| `retail` | 114 | Agent tools only |
+| `telecom` | 114 (sub-sampled from 2285) | User-simulator also gets tools (dual-control devices) |
+
+## Setup
+
+**Install dependencies** — tau2-bench is not on PyPI, so it is installed straight from GitHub, pinned to commit `6899b47` (see `requirements.txt` for why):
+
+```bash
+pip install -r requirements.txt
+```
+
+The DB, policy, and task data live in the tau2 repo (not the pip wheel); the eval benchmarks clone it into `./data/tau2-bench` at load time.
+
+## Usage
+
+```python
+from strands_env.environments.tau2_bench import Tau2BenchEnv
+
+env = Tau2BenchEnv(
+    agent_model_factory=agent_model_factory,    # the model under test
+    user_model_factory=user_model_factory,      # drives the user-simulator
+    judge_model_factory=judge_model_factory,    # optional; only used for NL-assertion reward
+    initial_db=initial_db,                       # pristine base DB for the domain
+    domain="retail",
+    task=task_dict,                              # one tau2 `Task`, as a dict
+    user_sim_guidelines=guidelines,
+    max_turns=100,
+)
+
+await env.reset()                # Build per-episode tau2 env, prime the user-sim
+result = await env.step(action)  # Runs the full multi-turn episode
+```
+
+`reset()` builds a fresh tau2 domain environment (applying `task.initial_state`), constructs the agent/user tools, and gets the user-sim's reply to a canned greeting to seed the agent's first turn. No `cleanup()` is needed — the DB is per-episode in-memory state.
+
+## Tools
+
+The agent's tools are the tau2 domain's own tools, adapted to Strands `AgentTool` via `Tau2BenchTool` and dispatched through tau2's `Environment.get_response` (so `sync_tools` runs after each call). In the `telecom` domain the user-simulator gets its own tool subset (`task.user_tools`). Numeric args to string-typed params are coerced to `str` to match function-calling API behavior (relevant for typeless tool-call formats like GLM).
+
+## Reward
+
+Built-in `Tau2BenchReward` computes the **product** of the sub-rewards named by each task's `reward_basis` (default `{DB, COMMUNICATE}` when unset):
+
+| Basis | Sub-reward |
+|---|---|
+| `DB` | Agent+user DB hashes match a golden env built by replaying `task.actions` on a fresh DB |
+| `ACTION` | Every golden action is matched by some tool call across agent + user-sim messages |
+| `COMMUNICATE` | Each required info string appears in some assistant message |
+| `NL_ASSERTION` | LLM judge (byte-aligned with tau2's prompt/schema) grades each expected outcome; needs `judge_model_factory` |
+| `ENV_ASSERTION` | Every `task.env_assertions` holds against the live post-episode env (telecom) |
+
+Supply a custom `reward_fn` to override.
+
+## Configuration
+
+Serializable config via `Tau2BenchConfig` (passed as `**kwargs`):
+
+- `domain` — `"airline"`, `"retail"`, or `"telecom"`
+- `task` — one tau2 `Task` serialized to a dict
+- `user_sim_guidelines` — system-prompt guidelines for the user-simulator
+- `max_turns` — turn cap before forced termination (default 100)
+
+Non-serializable params (named args):
+
+- `agent_model_factory` — model factory for the agent under test
+- `user_model_factory` — model factory for the user-simulator
+- `judge_model_factory` — optional model factory for the NL-assertion judge
+- `initial_db` — pristine base DB for the domain (deep-copied per episode)
+- `reward_fn` — optional override for the default `Tau2BenchReward`

--- a/src/strands_env/environments/tau2_bench/__init__.py
+++ b/src/strands_env/environments/tau2_bench/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tau2-bench environment: multi-turn customer-service eval (Sierra Research)."""
+
+from .env import Tau2BenchConfig, Tau2BenchEnv
+from .reward import Tau2BenchReward
+
+__all__ = ["Tau2BenchConfig", "Tau2BenchEnv", "Tau2BenchReward"]

--- a/src/strands_env/environments/tau2_bench/env.py
+++ b/src/strands_env/environments/tau2_bench/env.py
@@ -1,0 +1,242 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tau2-bench environment.
+
+Multi-turn agent vs LLM user-sim over a shared in-memory DB. One `env.step()`
+runs the full episode inside a single `agent.invoke_async()`, driven turn-by-turn
+by `Tau2BenchUserSimHook` via `AfterInvocationEvent.resume` (strands-agents >= 1.30.0).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import re
+from copy import deepcopy
+from typing import Any, Literal
+
+from strands import Agent
+from strands.agent import AgentResult
+from strands.agent.conversation_manager import NullConversationManager
+from strands.handlers.callback_handler import PrintingCallbackHandler
+from strands.hooks import AfterInvocationEvent, HookProvider, HookRegistry
+from strands.telemetry.metrics import EventLoopMetrics
+from typing_extensions import NotRequired, Unpack, override
+
+from strands_env.core import Action, Environment, ModelFactory
+from strands_env.core.environment import EnvironmentConfig
+from strands_env.core.types import RewardFunction, StepResult
+
+from .reward import Tau2BenchReward
+from .tool import Tau2BenchTool
+
+logger = logging.getLogger(__name__)
+
+#: Canned agent opening, seeded into agent history without an LLM call.
+DEFAULT_FIRST_AGENT_MESSAGE = "Hi! How can I help you today?"
+AGENT_INSTRUCTION = (
+    "You are a customer service agent that helps the user according to the <policy> provided below.\n"
+    "In each turn you can either:\n"
+    "- Send a message to the user.\n"
+    "- Make a tool call.\n"
+    "You cannot do both at the same time.\n\n"
+    "Try to be helpful and always follow the policy. Always make sure you generate valid JSON only."
+)
+AGENT_SYSTEM_PROMPT_TEMPLATE = (
+    "<instructions>\n{agent_instruction}\n</instructions>\n<policy>\n{domain_policy}\n</policy>"
+)
+USER_SYSTEM_PROMPT_TEMPLATE = "{guidelines}\n\n<scenario>\n{instructions}\n</scenario>"
+AGENT_STOP_RE = re.compile(r"###STOP###")
+USER_STOP_RE = re.compile(r"###(STOP|TRANSFER|OUT-OF-SCOPE)###")
+
+
+class Tau2BenchConfig(EnvironmentConfig):
+    """Serializable configuration for `Tau2BenchEnv`."""
+
+    domain: Literal["airline", "retail", "telecom"]
+    task: dict[str, Any]
+    user_sim_guidelines: str
+    max_turns: NotRequired[int]
+
+
+def _extract_text(agent_result: AgentResult | None) -> str:
+    """Return the text from an `AgentResult.message`, or empty string."""
+    if agent_result is None:
+        return ""
+    return next((b["text"] for b in agent_result.message.get("content") or [] if "text" in b), "")
+
+
+def build_tau2_env(domain: str, initial_db: Any, task: Any) -> Any:
+    """Build a fresh tau2 domain `Environment` from `initial_db`, applying `task.initial_state` if set."""
+    domain_mod = importlib.import_module(f"tau2.domains.{domain}.environment")
+    tau2_env = domain_mod.get_environment(db=deepcopy(initial_db))
+    if task.initial_state is not None:
+        tau2_env.set_state(
+            task.initial_state.initialization_data,
+            task.initial_state.initialization_actions,
+            [],  # no message_history resume
+        )
+    return tau2_env
+
+
+class Tau2BenchUserSimHook(HookProvider):
+    """Drive the multi-turn dialogue via `AfterInvocationEvent.resume`."""
+
+    def __init__(self, user_sim: Agent, max_turns: int):
+        """Initialize a `Tau2BenchUserSimHook` instance."""
+        self.user_sim = user_sim
+        self.max_turns = max_turns
+        self.turn_count = 0
+        self.termination: Literal["aborted", "agent_stop", "max_turns", "user_stop"] = "aborted"
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        """Subscribe to `AfterInvocationEvent`."""
+        registry.add_callback(AfterInvocationEvent, self._on_after_invocation)
+
+    async def _on_after_invocation(self, event: AfterInvocationEvent) -> None:
+        self.turn_count += 1
+        agent_text = _extract_text(event.result)
+        if AGENT_STOP_RE.search(agent_text):
+            self.termination = "agent_stop"
+            return
+        if self.turn_count >= self.max_turns:
+            self.termination = "max_turns"
+            return
+        try:
+            user_text = _extract_text(await self.user_sim.invoke_async(agent_text))
+        except Exception as e:
+            logger.warning("user-sim failed at turn %d: %s", self.turn_count, e)
+            self.termination = "aborted"
+            return
+        if USER_STOP_RE.search(user_text):
+            self.termination = "user_stop"
+            # Append the terminating user msg so it shows up in `observation.messages`.
+            event.agent.messages.append({"role": "user", "content": [{"text": user_text}]})
+            return
+        event.resume = user_text
+
+
+class Tau2BenchEnv(Environment):
+    """tau2-bench env: thin wrapper; multi-turn driven by `Tau2BenchUserSimHook`."""
+
+    def __init__(
+        self,
+        *,
+        agent_model_factory: ModelFactory,
+        user_model_factory: ModelFactory,
+        initial_db: Any,
+        reward_fn: RewardFunction | None = None,
+        judge_model_factory: ModelFactory | None = None,
+        **config: Unpack[Tau2BenchConfig],
+    ):
+        """Initialize a `Tau2BenchEnv` instance."""
+        super().__init__(model_factory=agent_model_factory, reward_fn=None, **config)  # type: ignore[misc]
+        self.user_model_factory = user_model_factory
+        self.initial_db = initial_db
+        self.domain: Literal["airline", "retail", "telecom"] = self.config["domain"]
+        self.task: dict[str, Any] = self.config["task"]
+        self.max_turns: int = self.config.get("max_turns", 100)
+
+        # Populated by `reset()`.
+        self.tau2_env: Any = None
+        self.user_sim: Agent | None = None
+        self.user_sim_hook: Tau2BenchUserSimHook | None = None
+        self.agent_tools: list = []
+        self.user_tools: list = []
+        self.first_user_msg: str = ""
+
+        self.reward_fn = reward_fn or Tau2BenchReward(
+            self,
+            judge_model=judge_model_factory() if judge_model_factory else None,
+        )
+
+    @override
+    async def reset(self) -> None:
+        """Build per-episode tau2 environment and prime the user-sim."""
+        from tau2.data_model.tasks import Task  # type: ignore[import-not-found]
+
+        task_obj = Task.model_validate(self.task)
+        tau2_env = build_tau2_env(self.domain, self.initial_db, task_obj)
+        self.tau2_env = tau2_env
+        self.agent_tools = [Tau2BenchTool(t, tau2_env, "assistant") for t in tau2_env.tools.get_tools().values()]
+        self.user_tools = (
+            [
+                Tau2BenchTool(t, tau2_env, "user")
+                for t in tau2_env.user_tools.get_tools(include=task_obj.user_tools).values()
+            ]
+            if tau2_env.user_tools
+            else []
+        )
+
+        self.system_prompt = AGENT_SYSTEM_PROMPT_TEMPLATE.format(
+            agent_instruction=AGENT_INSTRUCTION,
+            domain_policy=tau2_env.policy,
+        )
+        self.user_sim = Agent(
+            model=self.user_model_factory(),
+            tools=list(self.user_tools),
+            system_prompt=USER_SYSTEM_PROMPT_TEMPLATE.format(
+                guidelines=self.config["user_sim_guidelines"],
+                instructions=str(task_obj.user_scenario),
+            ),
+            conversation_manager=NullConversationManager(),
+            # Mirror base `step()`'s callback handling; default `None` silences user-sim stream.
+            callback_handler=PrintingCallbackHandler() if self.verbose else None,
+        )
+        # User-sim's reply to the canned greeting seeds the agent's first invoke;
+        # subsequent turns flow through `Tau2BenchUserSimHook` via `event.resume`.
+        self.first_user_msg = _extract_text(await self.user_sim.invoke_async(DEFAULT_FIRST_AGENT_MESSAGE))
+        self.user_sim_hook = Tau2BenchUserSimHook(self.user_sim, self.max_turns)
+
+    @override
+    async def step(self, action: Action) -> StepResult:
+        """Inject `first_user_msg` and the canned greeting history into the action."""
+        action.message = self.first_user_msg
+        action.task_context.conversation_history = [
+            {"role": "assistant", "content": [{"text": DEFAULT_FIRST_AGENT_MESSAGE}]}
+        ]
+        return await super().step(action)
+
+    @override
+    def get_tools(self) -> list:
+        """Return the agent-side tools."""
+        return list(self.agent_tools)
+
+    @override
+    def get_hooks(self) -> list:
+        """Return the multi-turn driver hook."""
+        return [self.user_sim_hook] if self.user_sim_hook is not None else []
+
+    @override
+    def compute_metrics(
+        self,
+        event_loop_metrics: EventLoopMetrics,
+        tool_parse_errors: dict[str, int] | None = None,
+    ) -> dict[str, Any]:
+        """Agent metrics plus tau2 termination and a `user_sim` sub-dict."""
+        metrics = super().compute_metrics(event_loop_metrics, tool_parse_errors)
+        if self.user_sim_hook is not None:
+            metrics["tau2_termination"] = self.user_sim_hook.termination
+            metrics["turn_count"] = self.user_sim_hook.turn_count
+        if self.user_sim is not None:
+            metrics["user_sim"] = {
+                "messages": list(self.user_sim.messages),
+                "message_count": len(self.user_sim.messages),
+                **super().compute_metrics(
+                    self.user_sim.event_loop_metrics,
+                    tool_parse_errors=getattr(self.user_sim.model, "tool_parse_errors", None),
+                ),
+            }
+        return metrics

--- a/src/strands_env/environments/tau2_bench/requirements.txt
+++ b/src/strands_env/environments/tau2_bench/requirements.txt
@@ -1,0 +1,4 @@
+# tau2-bench is not on PyPI, so it is installed straight from GitHub. 
+# Pinned to commit 6899b47: it is not the v1.0.0 tag commit, and later revisions 
+# eagerly import the voice chain (pyaudio + portaudio) the text-only domains never use.
+tau2 @ git+https://github.com/sierra-research/tau2-bench.git@6899b47c910d38750d23d363460f67938d8c3dfc

--- a/src/strands_env/environments/tau2_bench/reward.py
+++ b/src/strands_env/environments/tau2_bench/reward.py
@@ -1,0 +1,224 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reward for tau2-bench: product of sub-rewards selected by `task.reward_basis`."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+from strands.models import Model
+from strands.types.content import Message
+from typing_extensions import override
+
+from strands_env.core.types import Action, RewardFunction, RewardResult, StepResult
+from strands_env.rewards.llm_judge_reward import LLMJudgeReward
+
+if TYPE_CHECKING:
+    from .env import Tau2BenchEnv
+
+logger = logging.getLogger(__name__)
+
+
+class NLAssertion(BaseModel):
+    """One NL-assertion judgment; field names mirror tau2's JSON shape."""
+
+    expectedOutcome: str  # noqa: N815
+    reasoning: str
+    metExpectation: bool  # noqa: N815
+
+
+class NLJudgment(BaseModel):
+    """Mirrors tau2's expected JSON wrapper: ``{"results": [...]}``."""
+
+    results: list[NLAssertion]
+
+
+#: Verbatim system prompt from tau2's `evaluator_nl_assertions.py`.
+NL_JUDGE_SYSTEM_PROMPT = """
+TASK
+- You will be given a list of expected outcomes and a conversation that was collected during a test case run.
+- The conversation is between an agent and a customer.
+- Your job is to evaluate whether the agent satisfies each of the expected outcomes.
+- Grade each expected outcome individually.
+
+FORMAT
+- Your response should be a JSON object with the following fields:
+- `reasoning`: a short explanation for your classification
+- `metExpectation`: `true` if the agent satisfies the expected outcomes, `false` otherwise
+- `expectedOutcome`: repeat the expectation from the input that you are grading
+
+Example response structure:
+{
+    "results": [
+        {
+            "expectedOutcome": "<one of the expected outcomes from the input>",
+            "reasoning": "<reasoning trace>",
+            "metExpectation": <false or true>,
+        }
+    ]
+}
+""".strip()
+
+
+class Tau2BenchNLAssertionReward(LLMJudgeReward[NLJudgment]):
+    """LLM-judged NL_ASSERTION sub-reward; byte-aligned with tau2's prompt/schema."""
+
+    judgment_format = NLJudgment
+
+    def __init__(self, env: Tau2BenchEnv, judge_model: Model | list[Model]) -> None:
+        """Initialize a `Tau2BenchNLAssertionReward` instance."""
+        super().__init__(judge_model=judge_model, system_prompt=NL_JUDGE_SYSTEM_PROMPT)
+        self._env = env
+
+    @override
+    async def get_judge_prompt(self, action: Action, step_result: StepResult) -> str:
+        from tau2.data_model.tasks import Task  # type: ignore[import-not-found]
+
+        task = Task.model_validate(self._env.task)
+        assertions = list(task.evaluation_criteria.nl_assertions or [])
+        messages = list(action.task_context.conversation_history) + list(step_result.observation.messages)
+        lines = []
+        for m in messages:
+            for b in m.get("content") or []:
+                if "text" in b:
+                    lines.append(f"{m['role']}: {b['text']}")
+                elif "toolResult" in b:
+                    result_text = "".join(t.get("text", "") for t in b["toolResult"].get("content", []))
+                    lines.append(f"tool: {result_text}")
+        dialogue = "\n".join(lines)
+        return f"conversation:\n{dialogue}\n\nexpectedOutcomes:\n{assertions}"
+
+    @override
+    async def get_reward(self, judgment: NLJudgment | str) -> float:
+        if not isinstance(judgment, NLJudgment):
+            return 0.0
+        return float(all(r.metExpectation for r in judgment.results))
+
+
+class Tau2BenchReward(RewardFunction):
+    """Final reward = product of sub-rewards selected by `task.reward_basis`."""
+
+    def __init__(self, env: Tau2BenchEnv, judge_model: Model | list[Model] | None = None) -> None:
+        """Initialize a `Tau2BenchReward` instance."""
+        self._env = env
+        self._nl_judge = Tau2BenchNLAssertionReward(env, judge_model) if judge_model is not None else None
+
+    @override
+    async def compute(self, action: Action, step_result: StepResult) -> RewardResult:
+        from tau2.data_model.tasks import RewardType, Task  # type: ignore[import-not-found]
+
+        task = Task.model_validate(self._env.task)
+        basis_raw = task.evaluation_criteria.reward_basis
+        basis = set(basis_raw) if basis_raw is not None else {RewardType.DB, RewardType.COMMUNICATE}
+        messages = list(action.task_context.conversation_history) + list(step_result.observation.messages)
+
+        sub: dict[str, float] = {}
+        nl_judge_info: dict[str, Any] | None = None
+        if RewardType.DB in basis:
+            sub["db"] = _db_reward(self._env, task)
+        if RewardType.ENV_ASSERTION in basis:
+            sub["env_assertion"] = _env_assertion_reward(self._env, task)
+        if RewardType.ACTION in basis:
+            sub["action"] = _action_reward(self._env, messages, task)
+        if RewardType.COMMUNICATE in basis:
+            sub["communicate"] = _communicate_reward(messages, task)
+        if RewardType.NL_ASSERTION in basis:
+            sub["nl_assertion"], nl_judge_info = await self._nl_assertion_reward(action, step_result, task)
+
+        reward = 1.0
+        for v in sub.values():
+            reward *= v
+        info: dict[str, Any] = {
+            "sub_rewards": sub,
+            "reward_basis": [b.value for b in basis],
+        }
+        if nl_judge_info is not None:
+            info["nl_judge"] = nl_judge_info
+        return RewardResult(reward=reward, info=info)
+
+    async def _nl_assertion_reward(
+        self, action: Action, step_result: StepResult, task: Any
+    ) -> tuple[float, dict[str, Any] | None]:
+        """Return the NL_ASSERTION sub-reward and the judge's `info` (None when not judged).
+
+        Defaults to 1.0 with no `info` when there are no assertions or no judge_model.
+        """
+        if not (task.evaluation_criteria.nl_assertions or []):
+            return 1.0, None
+        if self._nl_judge is None:
+            logger.warning("NL_ASSERTION required but no judge_model; defaulting to 1.0")
+            return 1.0, None
+        result = await self._nl_judge.compute(action, step_result)
+        return result.reward, result.info
+
+
+def _db_reward(env: Tau2BenchEnv, task: Any) -> float:
+    """Return 1.0 iff the agent+user DB hashes match a golden env built by replaying `task.actions` on a fresh DB."""
+    from .env import build_tau2_env
+
+    gold = build_tau2_env(env.domain, env.initial_db, task)
+    for act in task.evaluation_criteria.actions or []:
+        try:
+            gold.make_tool_call(tool_name=act.name, requestor=act.requestor, **act.arguments)
+        except Exception as e:
+            logger.warning("Error in golden action %s(%s): %s", act.name, act.arguments, e)
+    return float(
+        gold.get_db_hash() == env.tau2_env.get_db_hash() and gold.get_user_db_hash() == env.tau2_env.get_user_db_hash()
+    )
+
+
+def _env_assertion_reward(env: Tau2BenchEnv, task: Any) -> float:
+    """Return 1.0 iff every `task.env_assertions` holds against the live post-episode env (telecom only)."""
+    return float(
+        all(
+            env.tau2_env.run_env_assertion(a, raise_assertion_error=False)
+            for a in task.evaluation_criteria.env_assertions or []
+        )
+    )
+
+
+def _action_reward(env: Tau2BenchEnv, messages: list[Message], task: Any) -> float:
+    """Return 1.0 iff every golden action is matched by some tool_use across agent + user-sim messages."""
+    from tau2.data_model.message import ToolCall  # type: ignore[import-not-found]
+
+    golden = task.evaluation_criteria.actions or []
+    if not golden:
+        return 1.0
+    all_messages = messages + (env.user_sim.messages if env.user_sim is not None else [])
+    tool_calls = [
+        ToolCall(id=b["toolUse"]["toolUseId"], name=b["toolUse"]["name"], arguments=b["toolUse"]["input"])
+        for m in all_messages
+        if m.get("role") == "assistant"
+        for b in m.get("content", [])
+        if isinstance(b, dict) and "toolUse" in b
+    ]
+    return float(all(any(g.compare_with_tool_call(tc) for tc in tool_calls) for g in golden))
+
+
+def _communicate_reward(messages: list[Message], task: Any) -> float:
+    """Return 1.0 iff each required info string appears in some assistant message (per-message search)."""
+    required = task.evaluation_criteria.communicate_info or []
+    if not required:
+        return 1.0
+    assistant_texts = [
+        "".join(b.get("text", "") for b in m.get("content", []) if isinstance(b, dict))
+        for m in messages
+        if m.get("role") == "assistant"
+    ]
+    # Per-message lower + comma-strip; each required info must match SOME message.
+    haystacks = [t.lower().replace(",", "") for t in assistant_texts if t]
+    return float(all(any(s.lower() in h for h in haystacks) for s in required))

--- a/src/strands_env/environments/tau2_bench/tool.py
+++ b/src/strands_env/environments/tau2_bench/tool.py
@@ -1,0 +1,95 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapt a tau2 `Tool` to a Strands `AgentTool`."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal
+
+from strands.tools.tools import AgentTool, ToolResultEvent
+from strands.types.tools import ToolGenerator, ToolResult, ToolResultContent, ToolSpec, ToolUse
+from typing_extensions import override
+
+
+class Tau2BenchTool(AgentTool):
+    """Strands `AgentTool` dispatching via tau2's `Environment.get_response` (which runs `sync_tools`)."""
+
+    def __init__(self, tau2_tool: Any, tau2_env: Any, requestor: Literal["assistant", "user"]):
+        """Initialize a `Tau2BenchTool` instance."""
+        super().__init__()
+        self._tau2_tool = tau2_tool
+        self._tau2_env = tau2_env
+        self._requestor: Literal["assistant", "user"] = requestor
+
+    @property
+    def tool_name(self) -> str:
+        """Return the tau2 tool name."""
+        return self._tau2_tool.name
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        """Build a Strands `ToolSpec`; description mirrors tau2's `short_desc + long_desc` join."""
+        description = self._tau2_tool.short_desc
+        if self._tau2_tool.long_desc:
+            description = description + "\n\n" + self._tau2_tool.long_desc
+        return {
+            "name": self._tau2_tool.name,
+            "description": description,
+            "inputSchema": {"json": self._tau2_tool.params.model_json_schema()},
+        }
+
+    @property
+    def tool_type(self) -> str:
+        """Strands tool type identifier."""
+        return "python"
+
+    def _coerce_args(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Stringify numbers passed to string-typed params.
+
+        The GLM tool-call format is typeless, so a numeric id (`product_id`, `zip`) arrives as an
+        `int` and tau2's string-keyed lookups miss. A function-calling API delivers args already
+        typed per schema; mirror that by coercing against the tau2 param schema before dispatch.
+        """
+        props = self._tau2_tool.params.model_json_schema().get("properties", {})
+        return {
+            key: str(value)
+            if isinstance(value, int | float)
+            and not isinstance(value, bool)
+            and props.get(key, {}).get("type") == "string"
+            else value
+            for key, value in args.items()
+        }
+
+    @override
+    async def stream(self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any) -> ToolGenerator:
+        """Invoke via `Environment.get_response` so `sync_tools` runs after each call."""
+        from tau2.data_model.message import ToolCall  # type: ignore[import-not-found]
+
+        call = ToolCall(
+            id=tool_use["toolUseId"],
+            name=self._tau2_tool.name,
+            arguments=self._coerce_args(tool_use["input"]),
+            requestor=self._requestor,
+        )
+        response = await asyncio.to_thread(self._tau2_env.get_response, call)
+        status: Literal["success", "error"] = "error" if response.error else "success"
+        yield ToolResultEvent(
+            ToolResult(
+                status=status,
+                toolUseId=tool_use["toolUseId"],
+                content=[ToolResultContent(text=response.content)],
+            )
+        )


### PR DESCRIPTION
## Summary

Adds the **tau2-bench** ([Sierra Research](https://github.com/sierra-research/tau2-bench))
multi-turn customer-service benchmark as a first-class environment plus its eval harness.

`Tau2BenchEnv` runs a full agent ↔ LLM-user-simulator dialogue over a shared in-memory
domain DB inside a single `agent.invoke_async()`, driven turn-by-turn by
`Tau2BenchUserSimHook` via `AfterInvocationEvent.resume`. Three domains: airline (50 tasks),
retail (114), telecom (114).

## Changes

- **`environments/tau2_bench/`** — new env package:
  - `env.py` — `Tau2BenchEnv` + `Tau2BenchUserSimHook` (multi-turn driver), `Tau2BenchConfig`.
  - `reward.py` — `Tau2BenchReward`: product of sub-rewards selected per task `reward_basis`
    (DB hash, action match, communicate-info, NL-assertion via `Tau2BenchNLAssertionReward`
    LLM judge, env-assertion).
  - `tool.py` — `Tau2BenchTool` adapting tau2 domain tools to Strands `AgentTool`.
  - `README.md`, `requirements.txt` (git-pinned tau2 @ 6899b47).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on env package + eval + examples
- [x] `mypy src/strands_env/environments/tau2_bench` — clean
- [x] e2e ran all three domains (airline / retail / telecom); results in line with the reference baseline.
