### PR TITLE
build(deps): add boto3-stubs to dev and type boto3 usage without ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "build>=0.10.0",
     # Type checking
     "mypy>=1.10.0",
+    "boto3-stubs",
 ]
 litellm = ["litellm"]
 harbor = [

--- a/src/strands_env/environments/agentcore_code/tool.py
+++ b/src/strands_env/environments/agentcore_code/tool.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from strands import tool
 
@@ -25,6 +25,22 @@ from .quotas import CodeInterpreterQuotas
 
 if TYPE_CHECKING:
     from strands_env.utils.aws import BotoClient
+
+
+class _CodeInterpreterClient(Protocol):
+    """Operations this toolkit calls on the dynamically-built bedrock-agentcore client.
+
+    Avoids depending on the per-service `boto3-stubs[bedrock-agentcore]` stub.
+    """
+
+    def start_code_interpreter_session(self, **kwargs: Any) -> dict[str, Any]:
+        """Start a code interpreter session."""
+
+    def invoke_code_interpreter(self, **kwargs: Any) -> dict[str, Any]:
+        """Invoke the code interpreter."""
+
+    def stop_code_interpreter_session(self, **kwargs: Any) -> dict[str, Any]:
+        """Stop a code interpreter session."""
 
 
 class CodeInterpreterToolkit:
@@ -57,7 +73,7 @@ class CodeInterpreterToolkit:
                 Create one `CodeInterpreterQuotas` instance and pass it to all toolkit
                 instances to enforce account-wide limits.
         """
-        self.client = client
+        self.client = cast(_CodeInterpreterClient, client)
         self.session_id: str | None = None
         self.session_name = session_name
         self.session_timeout_seconds = session_timeout_seconds

--- a/src/strands_env/utils/aws.py
+++ b/src/strands_env/utils/aws.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import boto3
 from botocore.client import BaseClient
@@ -105,7 +105,9 @@ def create_assumed_role_session(role_arn: str, role_session_name: str, region_na
         method="sts-assume-role",
     )
 
-    botocore_session = get_botocore_session()
+    # No public API to inject RefreshableCredentials; set the private attr directly
+    # (typed `Any` as `_credentials` isn't in botocore-stubs).
+    botocore_session: Any = get_botocore_session()
     botocore_session._credentials = session_credentials
     session = boto3.Session(botocore_session=botocore_session, region_name=region_name)
     logger.info("Created boto3 session with assumed role: role_arn=%s, region_name=%s", role_arn, session.region_name)
@@ -147,7 +149,10 @@ def get_client(
         )
     else:
         session = boto3.Session(region_name=region_name, profile_name=profile_name)
-    client = session.client(service_name, region_name=region_name, config=config)
+    # boto3-stubs types `.client()` only for literal service names; this helper
+    # takes a runtime str, so call through an untyped ref to get `BaseClient`.
+    create_client: Any = session.client
+    client: BotoClient = create_client(service_name, region_name=region_name, config=config)
     logger.info("Created cached boto3 client: service_name=%s, region_name=%s", service_name, client.meta.region_name)
     return client
 


### PR DESCRIPTION
## What

Adds `boto3-stubs` to the `[dev]` extra so mypy type-checks boto3 calls deterministically, and fixes the five findings it surfaces — **without any `# type: ignore`**.

## Why

CI installs no boto3 stubs today, so `boto3.client(...)` resolves to `Any` and every AWS call site is silently untyped (mypy is green only by omission). Any dev whose venv happens to have `boto3-stubs` then sees 5 "phantom" errors that CI doesn't. Pinning `boto3-stubs` in `[dev]` makes type-checking deterministic and gives real typing on the AWS code going forward.

## The 5 findings, fixed by typing (no ignores)

| Site | Cause | Fix |
|---|---|---|
| `aws.py` `create_assumed_role_session` | injects a `RefreshableCredentials` via the private `_credentials` attr (the public `set_credentials` only takes static key/secret strings, so there's no public alternative) | type the local botocore session `Any` (attr isn't in botocore-stubs) |
| `aws.py` `get_client` | boto3-stubs overloads `Session.client()` only on *literal* service names, no `str` fallback; this helper is generic over a runtime str | route the call through an untyped ref → documented `BaseClient` |
| `agentcore_code/tool.py` (×3) | boto3 builds clients dynamically, so bedrock-agentcore methods aren't on `BaseClient` | local `Protocol` pinning the 3 ops used + `cast` — no `boto3-stubs[bedrock-agentcore]` dep |

## Checks

- ✅ `mypy src/strands_env`: **Success, 0 issues** (was 5 errors with stubs present)
- ✅ `ruff check` / `format --check` clean
- ✅ unit tests: 177 passed, 5 skipped
- All changes are type-level only (`cast`/`Any` annotations) — runtime behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)