### PR TITLE
refactor(eval): spell out MetricFn type alias as MetricFunction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Holds the environment base, data types, model factories, and shared reward/tool 
 
 **registry.py** — Benchmark registry with `@register_eval(name)` decorator. Auto-discovers benchmark modules from `benchmarks/` subdirectory on first access. `get_benchmark(name)`, `list_benchmarks()`, and `list_unavailable_benchmarks()` for discovery. Modules with missing dependencies are tracked as unavailable.
 
-**metrics.py** — `compute_pass_at_k` implements the unbiased pass@k estimator. `MetricFn` type alias for pluggable metrics.
+**metrics.py** — `compute_pass_at_k` implements the unbiased pass@k estimator. `MetricFunction` type alias for pluggable metrics.
 
 **benchmarks/** — Benchmark evaluator modules. Each module uses `@register_eval` decorator. Auto-discovered on first registry access; missing dependencies cause module to be skipped with warning. Registered families: math (`aime-2024/2025/2026`, `hmmt-feb-2025/nov-2025/feb-2026`), QA/research (`gpqa-*`, `hle-verified-gold[-text]`, `simpleqa-verified`, `frames`, `sealqa-seal-0/hard`, `browsecomp`), instruction following (`ifeval`), MCP (`mcp-atlas`), and agentic-coding/terminal (`swebench-verified`, `terminal-bench-1/2/2.1`).
 

--- a/src/strands_env/eval/__init__.py
+++ b/src/strands_env/eval/__init__.py
@@ -15,14 +15,14 @@
 """Evaluation framework for running agentic benchmarks."""
 
 from .evaluator import AsyncEnvFactory, EvalSample, Evaluator
-from .metrics import MetricFn
+from .metrics import MetricFunction
 from .registry import get_benchmark, list_benchmarks, list_unavailable_benchmarks, register_eval
 
 __all__ = [
     "AsyncEnvFactory",
     "EvalSample",
     "Evaluator",
-    "MetricFn",
+    "MetricFunction",
     "get_benchmark",
     "list_benchmarks",
     "list_unavailable_benchmarks",

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -32,7 +32,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 from strands_env.core import Action, AsyncEnvFactory, Observation, StepResult
 
-from .metrics import MetricFn, compute_pass_at_k
+from .metrics import MetricFunction, compute_pass_at_k
 
 if TYPE_CHECKING:
     from strands_env.core.distributed import EnvironmentActorPool
@@ -113,7 +113,7 @@ class Evaluator:
         """
         return True
 
-    def get_metric_fns(self) -> list[MetricFn]:
+    def get_metric_fns(self) -> list[MetricFunction]:
         """Return metric functions for evaluation. Override to customize.
 
         Notes:

--- a/src/strands_env/eval/metrics.py
+++ b/src/strands_env/eval/metrics.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from .evaluator import EvalSample
 
 #: Type alias for metric function: takes results {prompt_id: [EvalSample, ...]}, returns {metric_name: value}.
-MetricFn = Callable[[dict[str, list["EvalSample"]]], dict[str, float]]
+MetricFunction = Callable[[dict[str, list["EvalSample"]]], dict[str, float]]
 
 
 def compute_pass_at_k(


### PR DESCRIPTION
## What

Renames the `MetricFn` type alias to `MetricFunction` (`eval/metrics.py`, plus its references in `eval/evaluator.py`, `eval/__init__` export, and CLAUDE.md).

## Why

`MetricFn` was the only callable type alias using the `Fn` abbreviation — its siblings `ModelFactory`, `AsyncEnvFactory`, and `EnvFactoryCreator` all spell out their suffix word. This makes type-alias naming uniform.

The `get_metric_fns()` method keeps its short name: it's a local identifier (like the `reward_fn` param/attr used throughout), where a short abbreviation is idiomatic. Only the *type alias* is normalized.

## Checks

- ✅ `ruff check` / `format --check` clean
- ✅ unit tests: 177 passed, 5 skipped
- ✅ type-clean for this change (the boto3 mypy errors seen locally are phantom from a `boto3-stubs` install; CI runs without stubs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)