### PR TITLE
fix(tau2-bench): use renamed MetricFunction in eval benchmark

### DIFF
--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -31,7 +31,7 @@ from strands_env.core import Action, TaskContext
 from strands_env.environments.tau2_bench import Tau2BenchConfig
 from strands_env.eval import Evaluator
 from strands_env.eval.evaluator import EvalSample
-from strands_env.eval.metrics import MetricFn, compute_pass_at_k
+from strands_env.eval.metrics import MetricFunction, compute_pass_at_k
 
 from ..registry import register_eval
 
@@ -131,7 +131,7 @@ class Tau2BenchEvaluator(Evaluator):
         return True
 
     @override
-    def get_metric_fns(self) -> list[MetricFn]:
+    def get_metric_fns(self) -> list[MetricFunction]:
         """Report both ``pass@k`` (at-least-one) and ``pass^k`` (consistency, tau2 paper)."""
         k_values = list(range(1, self.n_samples_per_prompt + 1))
         return [


### PR DESCRIPTION
## What

The tau2bench eval benchmark imports `MetricFn` from `eval.metrics`, but that type alias was renamed to `MetricFunction` in #156. Updates the import and the `get_metric_fns()` return annotation.

## Why

#154 (tau2bench eval) and #156 (`MetricFn` → `MetricFunction`) were developed in parallel and merged independently, so main ended up with `tau2_bench.py` referencing the old name. Line 34 is a **top-level import**, so on `main` this is a runtime `ImportError` when the module loads (the registry would silently mark `tau2bench` unavailable), not just a mypy `attr-defined` error.

## Checks

- ✅ mypy: tau2/benchmarks error cleared
- ✅ `ruff check` / `format --check` clean
- ✅ no remaining `MetricFn` references repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)