### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -28,7 +28,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -42,15 +42,15 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}


### PR DESCRIPTION
## What

Bumps the official `actions/*` GitHub Actions to their latest Node-24 majors across both workflows:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/cache` | v4 | v5 |

## Why

The **v0.5.1** PyPI publish run logged a Node.js 20 deprecation annotation — `actions/checkout@v4`, `actions/setup-python@v5`, and `actions/upload-artifact@v4` were being force-run on Node 24 because their pinned majors target the now-deprecated Node 20 runtime. These bumps move every official action to a major that runs on Node 24 natively, clearing the warning.

## Notes

- All bumped actions require a minimum Actions Runner of `2.327.1`; GitHub-hosted `ubuntu-latest` runners exceed this.
- `download-artifact@v8`'s behavioral changes (hash-mismatch-errors-by-default, ESM migration, skip-decompress for non-zip files) don't affect the standard zipped `dist/` artifact this pipeline uploads/downloads.
- Left unchanged: `pypa/gh-action-pypi-publish@release/v1` (a container action, not Node-based) and `codecov/codecov-action@v4` (third-party, not in the deprecation warning; v5 has separate token/input considerations — can be a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)