### PR TITLE
test: assert rate limiter timing on the full window, not per phase

### DIFF
--- a/tests/unit/environments/agentcore_code/test_code_interpreter.py
+++ b/tests/unit/environments/agentcore_code/test_code_interpreter.py
@@ -131,15 +131,21 @@ class TestCodeInterpreterToolkit:
             await toolkit.invoke("executeCode", {"code": "1", "language": "python"})
             timestamps.append(time.monotonic())
 
-        # First 10 calls use burst capacity (~instant), calls 11-13 are rate-limited
         burst_elapsed = (timestamps[9] - timestamps[0]) * 1000
-        throttled_elapsed = (timestamps[12] - timestamps[9]) * 1000
+        total_elapsed = (timestamps[12] - timestamps[0]) * 1000
 
-        # Burst phase should be fast (< 50ms for 10 calls)
-        assert burst_elapsed < 50, f"Burst took {burst_elapsed:.0f}ms, expected < 50ms"
-        # Throttled phase: 3 calls at 10 TPS = ~300ms (allow ±50ms tolerance)
-        assert throttled_elapsed > 250, f"Throttled phase took {throttled_elapsed:.0f}ms, expected > 250ms"
-        assert throttled_elapsed < 400, f"Throttled phase took {throttled_elapsed:.0f}ms, expected < 400ms"
+        # Per-phase timings are not load-robust: on a slow runner the burst phase leaks
+        # bucket refills that the nominally-throttled calls then consume, shrinking the
+        # throttled phase below its ideal duration. Only the full window has a guaranteed
+        # lower bound, so assert on that.
+        # First 10 calls ride burst capacity: far below the ~900ms a throttled-from-call-1
+        # limiter would take, generous enough to absorb scheduler noise on shared runners.
+        assert burst_elapsed < 500, f"Burst took {burst_elapsed:.0f}ms, expected < 500ms"
+        # 13 calls against capacity 10 at 10 TPS require >= 3 bucket refills, so the full
+        # window takes >= ~300ms no matter how the waiting is distributed across calls.
+        assert total_elapsed > 290, f"Total took {total_elapsed:.0f}ms, expected > 290ms"
+        # Sanity upper bound: expected ~300ms; loaded runs should still stay well under 1s.
+        assert total_elapsed < 1000, f"Total took {total_elapsed:.0f}ms, expected < 1000ms"
 
     async def test_semaphore_blocks_then_unblocks(self):
         """Measure that blocked toolkits resume promptly after cleanup."""


### PR DESCRIPTION
## Summary

`test_rate_limiter_throttles_invocations` asserts wall-clock time per phase and flaked on shared CI runners **in both directions** on the Python 3.10 job of #165 and this PR's first iteration:

- `Burst took 92ms/107ms, expected < 50ms` — slow runner breaks the burst upper bound
- `Throttled phase took 222ms, expected > 250ms` — the same slow burst leaks `AsyncLimiter` bucket refills (~1 token per 100ms of burst) that the nominally-throttled calls then consume, shrinking the throttled phase

The two phases are coupled through the bucket, so no per-phase threshold is load-robust. The **full window** is: 13 acquisitions against capacity 10 at 10 TPS require ≥ 3 refills, so it takes ≥ ~300ms no matter how the waiting is distributed — and load can only increase it. The test now asserts:

- Burst `< 500ms`: still far below the ~900ms a throttled-from-call-1 limiter would take
- Total `> 290ms`: the bucket-math lower bound (fails if the limiter is missing or not wired)
- Total `< 1000ms`: loose sanity bound (catches gross over-throttling, e.g. a 1 TPS misconfig at ~3s)

## Testing

- `tests/unit/environments/agentcore_code/test_code_interpreter.py`: 10 passed on Python 3.10 in an isolated uv venv

🤖 Generated with [Claude Code](https://claude.com/claude-code)