### PR TITLE
refactor(core)!: flatten Task, retire TaskContext

### DIFF
--- a/examples/bedrock_judge_demo.py
+++ b/examples/bedrock_judge_demo.py
@@ -33,7 +33,7 @@ import boto3
 import click
 from strands.models.bedrock import BedrockModel
 
-from strands_env.core.types import RolloutResult, Task, TaskContext, TerminationReason
+from strands_env.core.types import RolloutResult, Task, TerminationReason
 from strands_env.eval.benchmarks.simpleqa_verified import SimpleQAReward
 
 # ---------------------------------------------------------------------------
@@ -76,7 +76,7 @@ async def run_demo(model_id: str) -> None:
         click.echo(f"Response:     {response}")
         click.echo("-" * 60)
 
-        task = Task(message=question, context=TaskContext(ground_truth=ground_truth))
+        task = Task(message=question, ground_truth=ground_truth)
         result = create_mock_rollout_result(response)
 
         reward = await reward_fn.compute(task, result)

--- a/examples/calculator_demo.py
+++ b/examples/calculator_demo.py
@@ -36,7 +36,7 @@ from typing import Literal
 import click
 
 from strands_env.core.models import ModelConfig, build_model_factory
-from strands_env.core.types import Task, TaskContext
+from strands_env.core.types import Task
 from strands_env.environments.calculator import CalculatorEnv, MathVerifyReward
 
 MATH_PROBLEMS = [
@@ -76,7 +76,7 @@ async def run_demo(
         click.echo(f"Expected: {ground_truth}")
         click.echo("-" * 60)
 
-        task = Task(message=question, context=TaskContext(ground_truth=ground_truth))
+        task = Task(message=question, ground_truth=ground_truth)
         result = await env.rollout(task)
 
         click.echo(f"Termination: {result.termination_reason.value}")

--- a/examples/eval/mcp_atlas/env.py
+++ b/examples/eval/mcp_atlas/env.py
@@ -40,7 +40,6 @@ def create_env_factory(model_config: dict, **env_config):
     http_client = MCPAtlasEnv.create_client(base_url=docker_url)
 
     async def env_factory(task):
-        ctx = task.context
         # Each env gets its own reward_fn to avoid concurrent tasks overwriting
         # _current_claim / _response on a shared instance.
         reward_fn = MCPAtlasReward(judge_model=judge_models, max_model_retries=max_judge_retries)
@@ -48,7 +47,7 @@ def create_env_factory(model_config: dict, **env_config):
             model_factory=model_factory,
             http_client=http_client,
             reward_fn=reward_fn,
-            enabled_tools=ctx.enabled_tools,
+            enabled_tools=task.enabled_tools,
             **env_config,
         )
 

--- a/examples/eval/simple_math/simple_math_evaluator.py
+++ b/examples/eval/simple_math/simple_math_evaluator.py
@@ -23,7 +23,7 @@ The hook file must export `EvaluatorClass` (an Evaluator subclass).
 
 from collections.abc import Iterable
 
-from strands_env.core import Task, TaskContext
+from strands_env.core import Task
 from strands_env.eval import Evaluator
 
 
@@ -55,10 +55,8 @@ class SimpleMathEvaluator(Evaluator):
         for item in problems:
             yield Task(
                 message=item["prompt"],
-                context=TaskContext(
-                    id=item["id"],
-                    ground_truth=item["answer"],
-                ),
+                id=item["id"],
+                ground_truth=item["answer"],
             )
 
     def get_metric_fns(self):

--- a/examples/eval/swe_bench/swe_bench_env.py
+++ b/examples/eval/swe_bench/swe_bench_env.py
@@ -31,7 +31,6 @@ def create_env_factory(model_config: dict, **env_config):
 
     async def env_factory(task: Task) -> HarborEnv:
         """Create a new HarborEnv with its own container/pod."""
-        ctx = task.context
-        return HarborEnv(model_factory=model_factory, **ctx.config, **env_config)
+        return HarborEnv(model_factory=model_factory, **task.config, **env_config)
 
     return env_factory

--- a/examples/eval/tau2_bench/tau2_bench_env.py
+++ b/examples/eval/tau2_bench/tau2_bench_env.py
@@ -46,7 +46,7 @@ def create_env_factory(model_config: dict, **env_config: Any):
 
     async def env_factory(task: Task) -> Tau2BenchEnv:
         """Construct a fresh `Tau2BenchEnv` for one task."""
-        config = dict(task.context.config)  # type: ignore[attr-defined]
+        config = dict(task.config)  # type: ignore[attr-defined]
         return Tau2BenchEnv(
             agent_model_factory=agent_model_factory,
             user_model_factory=user_model_factory,

--- a/examples/eval/terminal_bench/terminal_bench_env.py
+++ b/examples/eval/terminal_bench/terminal_bench_env.py
@@ -27,7 +27,6 @@ def create_env_factory(model_config: dict, **env_config):
 
     async def env_factory(task: Task) -> HarborEnv:
         """Create a new HarborEnv with its own Docker container."""
-        ctx = task.context
-        return HarborEnv(model_factory=model_factory, **ctx.config, **env_config)
+        return HarborEnv(model_factory=model_factory, **task.config, **env_config)
 
     return env_factory

--- a/examples/slime/retool/generate_with_agentcore_code.py
+++ b/examples/slime/retool/generate_with_agentcore_code.py
@@ -29,7 +29,7 @@ from slime.utils.types import Sample  # type: ignore
 from strands_sglang import get_client_from_slime_args
 
 from strands_env.core.models import sglang_model_factory
-from strands_env.core.types import Task, TaskContext
+from strands_env.core.types import Task
 from strands_env.environments.agentcore_code import AgentCoreCodeEnv
 from strands_env.environments.agentcore_code.quotas import CodeInterpreterQuotas
 from strands_env.environments.calculator.reward import MathVerifyReward
@@ -85,10 +85,8 @@ async def generate_and_rm(args, sample: Sample, sampling_params) -> Sample:
     prompt = sample.prompt if isinstance(sample.prompt, str) else sample.prompt[0]["content"]
     task = Task(
         message=prompt,
-        context=TaskContext(
-            ground_truth=sample.label,
-            conversation_history=[],
-        ),
+        ground_truth=sample.label,
+        conversation_history=[],
     )
     result = await env.rollout(task)
 

--- a/src/strands_env/core/__init__.py
+++ b/src/strands_env/core/__init__.py
@@ -23,7 +23,6 @@ from .types import (
     RewardResult,
     RolloutResult,
     Task,
-    TaskContext,
     TerminationReason,
 )
 
@@ -39,6 +38,5 @@ __all__ = [
     "RewardFunction",
     "RewardResult",
     "RolloutResult",
-    "TaskContext",
     "TerminationReason",
 ]

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -106,7 +106,7 @@ class Environment:
     async def rollout(self, task: Task) -> RolloutResult:
         """Run one agent rollout and return its trajectory, reward, and termination reason."""
         # 1. Build inputs and the agent.
-        conversation_history = task.context.conversation_history
+        conversation_history = task.conversation_history
         limiter = LoopLimiter(
             max_tool_iters=self.max_tool_iters,
             max_tool_calls=self.max_tool_calls,

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -34,24 +34,20 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-class TaskContext(BaseModel):
-    """Ground truth, conversation history, and arbitrary task-specific fields.
+class Task(BaseModel):
+    """A single task containing the starting message and any additional context.
 
-    Extra kwargs are forwarded to reward functions (e.g. `TaskContext(ground_truth="4", difficulty=3)`).
+    Environments with per-sample payload should subclass `Task` with declared, typed fields
+    (e.g. a serialized task spec, per-task directories) — declared fields are validated as
+    usual. `extra="allow"` keeps undeclared fields for ad-hoc tasks without a subclass.
     """
 
     model_config = ConfigDict(extra="allow")
 
-    ground_truth: Any = None
-    conversation_history: Messages = Field(default_factory=list)
-
-
-class Task(BaseModel):
-    """A single task: an `id`, the message to send, and the context needed for reward computation."""
-
-    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    message: str | Message = Field(..., description="The message/prompt to send to the agent.")
-    context: TaskContext = Field(default_factory=TaskContext)
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()), description="The unique identifier for the task.")
+    message: str | Message = Field(..., description="The task message/prompt to send to the agent.")
+    ground_truth: Any = Field(default=None, description="The ground truth answer to the task.")
+    conversation_history: Messages = Field(default_factory=list, description="The conversation prior to the task.")
 
 
 # ---------------------------------------------------------------------------
@@ -60,10 +56,10 @@ class Task(BaseModel):
 
 
 class RewardResult(BaseModel):
-    """Scalar reward plus optional diagnostics."""
+    """Scalar reward plus optional diagnostic information."""
 
-    reward: float = Field(...)
-    info: dict[str, Any] = Field(default_factory=dict)
+    reward: float = Field(..., description="The reward scalar value.")
+    info: dict[str, Any] = Field(default_factory=dict, description="Additional diagnostic information.")
 
 
 class RewardFunction(ABC):
@@ -160,27 +156,6 @@ class TerminationReason(str, Enum):
 # ---------------------------------------------------------------------------
 
 
-def extract_message_text(message: Message) -> str:
-    """Extract the final text from a message: the last text block, with any think block stripped.
-
-    Returns an empty string when the message contains no text block.
-    An unclosed `<think>` block (truncated generation) is returned as-is.
-    """
-    content = message.get("content") or []
-    # Take the last text block — the final textual output.
-    text = next(
-        (block["text"] for block in reversed(content) if isinstance(block, dict) and "text" in block),
-        None,
-    )
-    if text is None:
-        return ""
-    # Strip think block if any: keep only what follows the last closing tag
-    think_end = text.rfind("</think>")
-    if think_end != -1:
-        text = text[think_end + len("</think>") :].lstrip()
-    return text
-
-
 class RolloutResult(BaseModel):
     """Result of a single `Environment.rollout` call: trajectory, reward, and termination."""
 
@@ -200,3 +175,24 @@ class RolloutResult(BaseModel):
         if not self.messages or self.messages[-1].get("role") != "assistant":
             return None
         return extract_message_text(self.messages[-1]) or None
+
+
+def extract_message_text(message: Message) -> str:
+    """Extract the final text from a message: the last text block, with any think block stripped.
+
+    Returns an empty string when the message contains no text block.
+    An unclosed `<think>` block (truncated generation) is returned as-is.
+    """
+    content = message.get("content") or []
+    # Take the last text block — the final textual output.
+    text = next(
+        (block["text"] for block in reversed(content) if isinstance(block, dict) and "text" in block),
+        None,
+    )
+    if text is None:
+        return ""
+    # Strip think block if any: keep only what follows the last closing tag
+    think_end = text.rfind("</think>")
+    if think_end != -1:
+        text = text[think_end + len("</think>") :].lstrip()
+    return text

--- a/src/strands_env/environments/agent_world_model/reward.py
+++ b/src/strands_env/environments/agent_world_model/reward.py
@@ -51,7 +51,7 @@ class AgentWorldModelReward(RewardFunction):
 
     async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
         """Run verification code against the agent's final response."""
-        ctx: Any = task.context
+        ctx: Any = task  # AWM task fields (verify_code, db paths, scenario) arrive as Task extras
         final_answer = result.final_response or ""
 
         try:

--- a/src/strands_env/environments/calculator/reward.py
+++ b/src/strands_env/environments/calculator/reward.py
@@ -105,7 +105,7 @@ class MathVerifyReward(RewardFunction):
 
     @override
     async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
-        ground_truth = task.context.ground_truth
+        ground_truth = task.ground_truth
         if not isinstance(ground_truth, str) or not ground_truth.strip():
             return RewardResult(reward=0.0, info={"reason": "invalid_ground_truth"})
 

--- a/src/strands_env/environments/mcp_atlas/reward.py
+++ b/src/strands_env/environments/mcp_atlas/reward.py
@@ -118,7 +118,7 @@ class MCPAtlasReward(LLMJudgeReward[ClaimJudgment]):
     @override
     async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
         """Evaluate each GTFA claim individually and return binary pass/fail reward."""
-        claims: list[str] = task.context.gtfa_claims  # type: ignore[attr-defined]
+        claims: list[str] = task.gtfa_claims  # type: ignore[attr-defined]
 
         if not claims:
             return RewardResult(reward=self.default_reward, info={"reason": "no_claims"})

--- a/src/strands_env/environments/tau2_bench/env.py
+++ b/src/strands_env/environments/tau2_bench/env.py
@@ -129,7 +129,7 @@ class Tau2BenchEnv(Environment):
         """Seed the greeting exchange into the task, then run the episode."""
         # task prompt is simulated by the user simulator
         task.message = await self.user_simulator.first_message()
-        task.context.conversation_history = [
+        task.conversation_history = [
             Message(role="assistant", content=[{"text": Tau2BenchUserSimulator.GREETING_MESSAGE}])
         ]
 

--- a/src/strands_env/environments/tau2_bench/nl_judge.py
+++ b/src/strands_env/environments/tau2_bench/nl_judge.py
@@ -85,7 +85,7 @@ class Tau2BenchNLAssertionReward(LLMJudgeReward[NLJudgment]):
     @override
     async def get_judge_prompt(self, task: Task, result: RolloutResult) -> str:
         assertions = list(self._env.tau2_task.evaluation_criteria.nl_assertions or [])
-        messages = list(task.context.conversation_history) + list(result.messages)
+        messages = list(task.conversation_history) + list(result.messages)
         lines = []
         for m in messages:
             for b in m.get("content") or []:

--- a/src/strands_env/environments/tau2_bench/reward.py
+++ b/src/strands_env/environments/tau2_bench/reward.py
@@ -55,7 +55,7 @@ class Tau2BenchReward(RewardFunction):
         reward_type = _tau2.RewardType
         basis_raw = self._env.tau2_task.evaluation_criteria.reward_basis
         basis = set(basis_raw) if basis_raw is not None else {reward_type.DB, reward_type.COMMUNICATE}
-        messages = list(task.context.conversation_history) + list(result.messages)
+        messages = list(task.conversation_history) + list(result.messages)
 
         sub_rewards: dict[str, float] = {}
         nl_judge_info: dict[str, Any] | None = None

--- a/src/strands_env/eval/benchmarks/aime.py
+++ b/src/strands_env/eval/benchmarks/aime.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable
 from datasets import load_dataset
 from typing_extensions import override
 
-from strands_env.core import Task, TaskContext
+from strands_env.core import Task
 
 from ..evaluator import Evaluator
 from ..registry import register_eval
@@ -53,9 +53,7 @@ class AIMEEvaluator(Evaluator):
             yield Task(
                 id=f"{self.benchmark_name}_{row.get('id', i)}",
                 message=str(problem),
-                context=TaskContext(
-                    ground_truth=str(answer),
-                ),
+                ground_truth=str(answer),
             )
 
 

--- a/src/strands_env/eval/benchmarks/browsecomp.py
+++ b/src/strands_env/eval/benchmarks/browsecomp.py
@@ -26,7 +26,7 @@ import pandas as pd
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
-from strands_env.core import RolloutResult, Task, TaskContext
+from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 
 from ..evaluator import EvalSample, Evaluator
@@ -79,7 +79,7 @@ class BrowseCompReward(LLMJudgeReward[BrowseCompJudgment]):
         """Get judge prompt for BrowseComp benchmark."""
         return GRADER_TEMPLATE.format(
             query=task.message,
-            ground_truth=task.context.ground_truth,
+            ground_truth=task.ground_truth,
             model_response=result.final_response,
         )
 
@@ -139,9 +139,7 @@ class BrowseCompEvaluator(Evaluator):
             yield Task(
                 id=f"{self.benchmark_name}_{i}",
                 message=decrypted_problem,
-                context=TaskContext(
-                    ground_truth=decrypted_answer,
-                ),
+                ground_truth=decrypted_answer,
             )
 
     # ---------------------------------------------------------------------------

--- a/src/strands_env/eval/benchmarks/frames.py
+++ b/src/strands_env/eval/benchmarks/frames.py
@@ -18,13 +18,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Literal
+from typing import Any, Literal
 
 from datasets import load_dataset
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
-from strands_env.core import RolloutResult, Task, TaskContext
+from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 
 from ..evaluator import EvalSample, Evaluator
@@ -62,6 +62,13 @@ class FramesJudgment(BaseModel):
     )
 
 
+class FramesTask(Task):
+    """`Task` with FRAMES row metadata (kept for reporting/analysis)."""
+
+    wiki_links: Any = None
+    reasoning_types: Any = None
+
+
 class FramesReward(LLMJudgeReward[FramesJudgment]):
     """Reward for FRAMES benchmark."""
 
@@ -72,7 +79,7 @@ class FramesReward(LLMJudgeReward[FramesJudgment]):
         """Get judge prompt for FRAMES benchmark."""
         return GRADER_TEMPLATE.format(
             query=task.message,
-            ground_truth=task.context.ground_truth,
+            ground_truth=task.ground_truth,
             model_response=result.final_response,
         )
 
@@ -114,14 +121,10 @@ class FramesEvaluator(Evaluator):
                 logger.warning("Row %s: missing Prompt/Answer, skipped", i)
                 continue
 
-            yield Task(
+            yield FramesTask(
                 id=f"{self.benchmark_name}_{i}",
                 message=str(prompt),
-                context=TaskContext(
-                    ground_truth=str(answer),
-                    **{
-                        "wiki_links": row["wiki_links"],
-                        "reasoning_types": row["reasoning_types"],
-                    },
-                ),
+                ground_truth=str(answer),
+                wiki_links=row["wiki_links"],
+                reasoning_types=row["reasoning_types"],
             )

--- a/src/strands_env/eval/benchmarks/gpqa.py
+++ b/src/strands_env/eval/benchmarks/gpqa.py
@@ -26,13 +26,21 @@ from collections.abc import Iterable
 from datasets import load_dataset
 from typing_extensions import override
 
-from strands_env.core import Task, TaskContext
+from strands_env.core import Task
 from strands_env.core.types import RewardFunction, RewardResult, RolloutResult
 
 from ..evaluator import Evaluator
 from ..registry import register_eval
 
 logger = logging.getLogger(__name__)
+
+
+class GPQATask(Task):
+    """`Task` with the shuffled choice sheet needed to grade a letter answer."""
+
+    subdomain: str = ""
+    correct_letter: str
+    choices: list[str]
 
 
 class GPQAReward(RewardFunction):
@@ -62,12 +70,12 @@ class GPQAReward(RewardFunction):
     async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
         """Extract the answer letter and compare with the correct choice."""
         response = result.final_response or ""
-        correct_letter: str | None = getattr(task.context, "correct_letter", None)
+        correct_letter: str | None = getattr(task, "correct_letter", None)
 
         if correct_letter is None:
-            return RewardResult(reward=0.0, info={"status": "error", "error": "missing correct_letter in TaskContext"})
+            return RewardResult(reward=0.0, info={"status": "error", "error": "missing correct_letter on Task"})
 
-        choices: list[str] | None = getattr(task.context, "choices", None)
+        choices: list[str] | None = getattr(task, "choices", None)
         extracted = self.extract_answer(response, choices)
         is_correct = extracted is not None and extracted.upper() == correct_letter.upper()
 
@@ -197,17 +205,13 @@ class GPQAEvaluator(Evaluator):
                 f'Format your response as follows: "The correct answer is (insert answer here)"'
             )
 
-            yield Task(
+            yield GPQATask(
                 id=f"{self.benchmark_name}_{i}",
                 message=formatted_question,
-                context=TaskContext(
-                    ground_truth=str(correct_answer),
-                    **{
-                        "subdomain": row.get("Subdomain", ""),
-                        "correct_letter": correct_letter,
-                        "choices": choices,
-                    },
-                ),
+                ground_truth=str(correct_answer),
+                subdomain=row.get("Subdomain", ""),
+                correct_letter=correct_letter,
+                choices=choices,
             )
 
 

--- a/src/strands_env/eval/benchmarks/hle_verified.py
+++ b/src/strands_env/eval/benchmarks/hle_verified.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 from strands.types.content import Message
 from typing_extensions import override
 
-from strands_env.core import RolloutResult, Task, TaskContext
+from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 
 from ..evaluator import EvalSample, Evaluator
@@ -75,6 +75,15 @@ class HLEJudgment(BaseModel):
     )
 
 
+class HLEVerifiedTask(Task):
+    """`Task` with HLE metadata used for judging and reporting."""
+
+    answer_type: str | None = None
+    raw_subject: str | None = None
+    category: str | None = None
+    has_image: bool = False
+
+
 class HLEReward(LLMJudgeReward[HLEJudgment]):
     """Reward for HLE-Verified benchmark."""
 
@@ -85,7 +94,7 @@ class HLEReward(LLMJudgeReward[HLEJudgment]):
         """Get judge prompt for HLE-Verified benchmark."""
         return GRADER_TEMPLATE.format(
             query=task.message,
-            ground_truth=task.context.ground_truth,
+            ground_truth=task.ground_truth,
             model_response=result.final_response,
         )
 
@@ -184,18 +193,14 @@ class HLEVerifiedEvaluator(Evaluator):
                     ],
                 }
 
-            yield Task(
+            yield HLEVerifiedTask(
                 id=f"{self.benchmark_name}_{row.get('id', i)}",
                 message=message,
-                context=TaskContext(
-                    ground_truth=str(answer),
-                    **{
-                        "answer_type": meta.get("answer_type"),
-                        "raw_subject": row.get("raw_subject"),
-                        "category": row.get("category"),
-                        "has_image": bool(image_data_url),
-                    },
-                ),
+                ground_truth=str(answer),
+                answer_type=meta.get("answer_type"),
+                raw_subject=row.get("raw_subject"),
+                category=row.get("category"),
+                has_image=bool(image_data_url),
             )
 
 

--- a/src/strands_env/eval/benchmarks/hmmt.py
+++ b/src/strands_env/eval/benchmarks/hmmt.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable
 from datasets import load_dataset
 from typing_extensions import override
 
-from strands_env.core import Task, TaskContext
+from strands_env.core import Task
 
 from ..evaluator import Evaluator
 from ..registry import register_eval
@@ -53,9 +53,7 @@ class HMMTEvaluator(Evaluator):
             yield Task(
                 id=f"{self.benchmark_name}_{row.get('problem_idx', i)}",
                 message=str(problem),
-                context=TaskContext(
-                    ground_truth=str(answer),
-                ),
+                ground_truth=str(answer),
             )
 
 

--- a/src/strands_env/eval/benchmarks/ifeval.py
+++ b/src/strands_env/eval/benchmarks/ifeval.py
@@ -24,7 +24,7 @@ from datasets import load_dataset
 from lm_eval.tasks.ifeval.utils import process_results
 from typing_extensions import override
 
-from strands_env.core import Task, TaskContext
+from strands_env.core import Task
 from strands_env.core.types import RewardFunction, RewardResult, RolloutResult
 
 from ..evaluator import Evaluator
@@ -39,6 +39,14 @@ IFEVAL_METRICS = (
     "inst_level_strict_acc",
     "inst_level_loose_acc",
 )
+
+
+class IFEvalTask(Task):
+    """`Task` carrying the IFEval row fields the grader needs."""
+
+    key: int = 0
+    instruction_id_list: list[Any] = []
+    ifeval_kwargs: list[Any] = []
 
 
 class IFEvalReward(RewardFunction):
@@ -75,14 +83,13 @@ class IFEvalReward(RewardFunction):
     async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
         """Run the IFEval grader on the final response and return a `RewardResult`."""
         response = result.final_response or ""
-        ctx = task.context
 
         # `process_results` expects a `doc` dict mirroring the original IFEval JSONL row.
         doc: dict[str, Any] = {
-            "key": getattr(ctx, "key", 0),
-            "instruction_id_list": list(getattr(ctx, "instruction_id_list", [])),
+            "key": getattr(task, "key", 0),
+            "instruction_id_list": list(getattr(task, "instruction_id_list", [])),
             "prompt": task.message if isinstance(task.message, str) else "",
-            "kwargs": list(getattr(ctx, "ifeval_kwargs", [])),
+            "kwargs": list(getattr(task, "ifeval_kwargs", [])),
         }
 
         try:
@@ -108,7 +115,7 @@ class IFEvalEvaluator(Evaluator):
     """Evaluator for IFEval (Instruction-Following Eval).
 
     Loads the 541-row [google/IFEval](https://huggingface.co/datasets/google/IFEval)
-    dataset and emits one `Task` per row. Each `TaskContext` carries the `key`,
+    dataset and emits one `Task` per row. Each `Task` carries the `key`,
     `instruction_id_list`, and `ifeval_kwargs` fields needed by `IFEvalReward` to
     run the rule-based grader. Pair this evaluator with an `IFEvalReward` instance
     on the environment.
@@ -122,7 +129,7 @@ class IFEvalEvaluator(Evaluator):
         """Load the IFEval dataset from HuggingFace (streaming).
 
         Yields:
-            Task objects. Each `TaskContext` stores the IFEval `key`,
+            Task objects. Each `Task` stores the IFEval `key`,
             `instruction_id_list`, and `ifeval_kwargs` as extras.
         """
         dataset = load_dataset(self.dataset_path, split="train", streaming=True)
@@ -132,13 +139,10 @@ class IFEvalEvaluator(Evaluator):
             if not prompt:
                 logger.warning("Row %s: missing prompt, skipped", i)
                 continue
-            extras: dict[str, Any] = {
-                "key": int(row.get("key", i)),
-                "instruction_id_list": list(row.get("instruction_id_list", [])),
-                "ifeval_kwargs": list(row.get("kwargs", [])),
-            }
-            yield Task(
+            yield IFEvalTask(
                 id=f"{self.benchmark_name}_{row.get('key', i)}",
                 message=str(prompt),
-                context=TaskContext(**extras),
+                key=int(row.get("key", i)),
+                instruction_id_list=list(row.get("instruction_id_list", [])),
+                ifeval_kwargs=list(row.get("kwargs", [])),
             )

--- a/src/strands_env/eval/benchmarks/mcp_atlas.py
+++ b/src/strands_env/eval/benchmarks/mcp_atlas.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable
 
 from typing_extensions import override
 
-from strands_env.core import AsyncEnvFactory, Task, TaskContext
+from strands_env.core import AsyncEnvFactory, Task
 from strands_env.eval import EvalSample, Evaluator
 
 from ..registry import register_eval
@@ -57,8 +57,8 @@ DEFAULT_SERVERS = frozenset(
 )
 
 
-class MCPAtlasTaskContext(TaskContext):
-    """TaskContext with MCP-Atlas-specific fields."""
+class MCPAtlasTask(Task):
+    """`Task` with MCP-Atlas-specific fields."""
 
     enabled_tools: list[str]
     gtfa_claims: list[str]
@@ -129,12 +129,15 @@ class MCPAtlasEvaluator(Evaluator):
             # that break ast.literal_eval, so escape them first.
             gtfa_claims = ast.literal_eval(row["GTFA_CLAIMS"].replace("\n", "\\n"))
 
-            ctx = MCPAtlasTaskContext(
-                enabled_tools=enabled_tools,
-                gtfa_claims=gtfa_claims,
-                ground_truth=row["PROMPT"],
+            tasks.append(
+                MCPAtlasTask(
+                    id=row["TASK"],
+                    message=row["PROMPT"],
+                    enabled_tools=enabled_tools,
+                    gtfa_claims=gtfa_claims,
+                    ground_truth=row["PROMPT"],
+                )
             )
-            tasks.append(Task(id=row["TASK"], message=row["PROMPT"], context=ctx))
 
         logger.info(
             "MCP-Atlas: loaded %d tasks (%d skipped — require unavailable servers)",

--- a/src/strands_env/eval/benchmarks/sealqa.py
+++ b/src/strands_env/eval/benchmarks/sealqa.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
+from typing import Any
 
 from datasets import load_dataset
 from typing_extensions import override
 
-from strands_env.core import Task, TaskContext
+from strands_env.core import Task
 
 from ..evaluator import EvalSample, Evaluator
 from ..registry import register_eval
@@ -36,6 +37,17 @@ SealQAReward = SimpleQAReward
 # ---------------------------------------------------------------------------
 # Evaluators — Seal-0 and Seal-Hard
 # ---------------------------------------------------------------------------
+
+
+class SealQATask(Task):
+    """`Task` with SealQA row metadata (kept for reporting/analysis)."""
+
+    freshness: Any = None
+    question_types: Any = None
+    effective_year: Any = None
+    search_results: Any = None
+    topic: Any = None
+    urls: Any = None
 
 
 class SealQAEvaluator(Evaluator):
@@ -68,20 +80,16 @@ class SealQAEvaluator(Evaluator):
                 logger.warning("Row %s: missing question/answer, skipped", i)
                 continue
 
-            yield Task(
+            yield SealQATask(
                 id=f"{self.benchmark_name}_{i}",
                 message=str(question),
-                context=TaskContext(
-                    ground_truth=str(answer),
-                    **{
-                        "freshness": row.get("freshness"),
-                        "question_types": row.get("question_types"),
-                        "effective_year": row.get("effective_year"),
-                        "search_results": row.get("search_results"),
-                        "topic": row.get("topic"),
-                        "urls": row.get("urls"),
-                    },
-                ),
+                ground_truth=str(answer),
+                freshness=row.get("freshness"),
+                question_types=row.get("question_types"),
+                effective_year=row.get("effective_year"),
+                search_results=row.get("search_results"),
+                topic=row.get("topic"),
+                urls=row.get("urls"),
             )
 
 

--- a/src/strands_env/eval/benchmarks/simpleqa_verified.py
+++ b/src/strands_env/eval/benchmarks/simpleqa_verified.py
@@ -24,7 +24,7 @@ from datasets import load_dataset
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
-from strands_env.core import RolloutResult, Task, TaskContext
+from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 
 from ..evaluator import EvalSample, Evaluator
@@ -131,7 +131,7 @@ class SimpleQAReward(LLMJudgeReward[SimpleQAJudgment]):
         """Get judge prompt for SimpleQA-Verified benchmarks."""
         return GRADER_TEMPLATE.format(
             query=task.message,
-            ground_truth=task.context.ground_truth,
+            ground_truth=task.ground_truth,
             model_response=result.final_response,
         )
 
@@ -175,7 +175,5 @@ class SimpleQAVerifiedEvaluator(Evaluator):
             yield Task(
                 id=f"{self.benchmark_name}_{row.get('original_index', i)}",
                 message=str(problem),
-                context=TaskContext(
-                    ground_truth=str(answer),
-                ),
+                ground_truth=str(answer),
             )

--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -25,7 +25,7 @@ from typing import ClassVar, Literal
 
 from typing_extensions import override
 
-from strands_env.core import Task, TaskContext
+from strands_env.core import Task
 from strands_env.environments.tau2_bench import Tau2BenchConfig, _tau2
 from strands_env.eval import Evaluator
 from strands_env.eval.evaluator import EvalSample
@@ -40,8 +40,8 @@ os.environ.setdefault("TAU2_DATA_DIR", str((DATA_DIR / "data").resolve()))
 logger = logging.getLogger(__name__)
 
 
-class Tau2BenchTaskContext(TaskContext):
-    """`TaskContext` for tau2-bench."""
+class Tau2BenchTask(Task):
+    """`Task` carrying the tau2-bench env config."""
 
     config: Tau2BenchConfig
 
@@ -71,15 +71,13 @@ class Tau2BenchEvaluator(Evaluator):
             self._download_dataset()
         tasks = [task.model_dump(mode="json") for task in _tau2.get_tasks(self.domain)]
         return [
-            Task(
+            Tau2BenchTask(
                 id=str(task["id"]),
-                message="",  # set by Tau2BenchEnv.rollout() from env.first_user_msg (after reset)
-                context=Tau2BenchTaskContext(
-                    ground_truth=(task.get("evaluation_criteria") or {}).get("reward_basis"),
-                    config=Tau2BenchConfig(
-                        domain=self.domain,
-                        tau2_task=task,
-                    ),
+                message="",  # set by Tau2BenchEnv.rollout() from the user-sim's first message
+                ground_truth=(task.get("evaluation_criteria") or {}).get("reward_basis"),
+                config=Tau2BenchConfig(
+                    domain=self.domain,
+                    tau2_task=task,
                 ),
             )
             for task in tasks

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from harbor.models.task.task import Task as HarborTask
 from typing_extensions import override
 
-from strands_env.core import Task, TaskContext
+from strands_env.core import Task
 from strands_env.environments.harbor import HarborConfig
 from strands_env.eval import Evaluator
 from strands_env.eval.evaluator import EvalSample
@@ -31,8 +31,8 @@ from strands_env.eval.evaluator import EvalSample
 from ..registry import register_eval
 
 
-class TerminalBenchTaskContext(TaskContext):
-    """TaskContext with Harbor task config."""
+class TerminalBenchTask(Task):
+    """`Task` carrying the Harbor task config."""
 
     config: HarborConfig
 
@@ -83,10 +83,10 @@ class TerminalBenchEvaluator(Evaluator):
         }
         if self.system_prompt_path is not None:
             config["system_prompt"] = self.system_prompt_path.read_text().strip()
-        return Task(
+        return TerminalBenchTask(
             id=task.name,
             message=task.instruction,
-            context=TerminalBenchTaskContext(config=config),
+            config=config,
         )
 
     @override
@@ -100,15 +100,14 @@ class TerminalBenchEvaluator(Evaluator):
     @override
     async def evaluate_sample(self, task: Task) -> EvalSample:
         """Override to create sample-specific output directories for pass@k."""
-        assert isinstance(task.context, TerminalBenchTaskContext)
-        ctx = task.context
+        assert isinstance(task, TerminalBenchTask)
         sample_idx = int(task.id.rsplit("_", 1)[1]) if "_" in task.id else 0
-        ctx.config["trial_dir"] = str(self.output_path.parent / ctx.config["task_id"] / str(sample_idx))
+        task.config["trial_dir"] = str(self.output_path.parent / task.config["task_id"] / str(sample_idx))
 
         sample = await super().evaluate_sample(task)
 
         # Save agent messages
-        agent_dir = Path(ctx.config["trial_dir"]) / "agent"
+        agent_dir = Path(task.config["trial_dir"]) / "agent"
         agent_dir.mkdir(parents=True, exist_ok=True)
         (agent_dir / "messages.json").write_text(json.dumps(sample.result.messages, indent=2, default=str))
         return sample

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -186,7 +186,7 @@ class Evaluator:
                 task.id,
                 result.termination_reason.value,
                 reward_str,
-                task.context.ground_truth,
+                task.ground_truth,
                 reward_info,
                 result.metrics,
             )

--- a/tests/integration/test_agentcore_code.py
+++ b/tests/integration/test_agentcore_code.py
@@ -21,7 +21,7 @@ Requires:
 
 import pytest
 
-from strands_env.core.types import RewardResult, RolloutResult, Task, TaskContext, TerminationReason
+from strands_env.core.types import RewardResult, RolloutResult, Task, TerminationReason
 from strands_env.environments.agentcore_code import AgentCoreCodeEnv
 from strands_env.utils.aws import check_credentials, get_client, get_session
 
@@ -99,7 +99,7 @@ class TestAgentCoreCodeEnv:
         class ContainsReward:
             async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
                 response = result.final_response or ""
-                expected = str(task.context.ground_truth)
+                expected = str(task.ground_truth)
                 return RewardResult(reward=1.0 if expected in response else 0.0)
 
         env = AgentCoreCodeEnv(
@@ -115,7 +115,8 @@ class TestAgentCoreCodeEnv:
             result2 = await env.rollout(
                 Task(
                     message="Now use code to compute x * 2 and give me the final number.",
-                    context=TaskContext(conversation_history=result1.messages, ground_truth=84),
+                    conversation_history=result1.messages,
+                    ground_truth=84,
                 ),
             )
             assert result2.termination_reason == TerminationReason.TASK_COMPLETE

--- a/tests/integration/test_calculator_env.py
+++ b/tests/integration/test_calculator_env.py
@@ -20,7 +20,7 @@ Exercises the full rollout lifecycle: agent invocation → result
 Requires a running SGLang server (default: http://localhost:30000).
 """
 
-from strands_env.core.types import Task, TaskContext, TerminationReason
+from strands_env.core.types import Task, TerminationReason
 from strands_env.environments.calculator import CalculatorEnv
 from strands_env.environments.calculator.reward import MathVerifyReward
 
@@ -63,7 +63,7 @@ class TestCalculatorEnv:
         result2 = await env.rollout(
             Task(
                 message="Now multiply that result by 3.",
-                context=TaskContext(conversation_history=result1.messages),
+                conversation_history=result1.messages,
             )
         )
         assert result2.termination_reason == TerminationReason.TASK_COMPLETE
@@ -76,7 +76,7 @@ class TestCalculatorEnv:
             reward_fn=MathVerifyReward(),
         )
         result = await env.rollout(
-            Task(message="What is 6 * 7?", context=TaskContext(ground_truth="42")),
+            Task(message="What is 6 * 7?", ground_truth="42"),
         )
 
         assert result.reward_result is not None

--- a/tests/integration/test_harbor.py
+++ b/tests/integration/test_harbor.py
@@ -27,7 +27,7 @@ import pytest
 
 pytest.importorskip("harbor", reason="harbor>=0.1.43 required for harbor env integration tests")
 
-from strands_env.core.types import Task, TaskContext, TerminationReason
+from strands_env.core.types import Task, TerminationReason
 from strands_env.environments.harbor import HarborEnv
 
 from .conftest import assert_rollout, assert_successful_rollout, assert_token_usage
@@ -118,7 +118,7 @@ class TestHarborEnv:
         result2 = await harbor_env.rollout(
             Task(
                 message="Now run 'echo world'.",
-                context=TaskContext(conversation_history=result1.messages),
+                conversation_history=result1.messages,
             ),
         )
         assert result2.termination_reason == TerminationReason.TASK_COMPLETE

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from click.testing import CliRunner
 
-from strands_env.core import Environment, RewardResult, RolloutResult, Task, TaskContext
+from strands_env.core import Environment, RewardResult, RolloutResult, Task
 from strands_env.eval import EvalSample
 
 # ---------------------------------------------------------------------------
@@ -30,7 +30,7 @@ from strands_env.eval import EvalSample
 def make_sample(reward: float, idx: int = 0, aborted: bool = False) -> EvalSample:
     """Create an EvalSample with the given reward and optional abort flag."""
     return EvalSample(
-        task=Task(id=f"sample_{idx}", message="q", context=TaskContext()),
+        task=Task(id=f"sample_{idx}", message="q"),
         result=RolloutResult(reward_result=RewardResult(reward=reward)),
         aborted=aborted,
     )

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -23,7 +23,6 @@ from strands_env.core.environment import Environment
 from strands_env.core.types import (
     RewardResult,
     Task,
-    TaskContext,
     TerminationReason,
 )
 
@@ -72,7 +71,7 @@ class TestRollout:
 
         task = Task(
             message="What is 2+2?",
-            context=TaskContext(conversation_history=conversation_history),
+            conversation_history=conversation_history,
         )
         result = await env.rollout(task)
 
@@ -103,7 +102,7 @@ class TestRollout:
         reward_fn.compute = AsyncMock(return_value=RewardResult(reward=1.0))
         env = Environment(model_factory=model_factory, reward_fn=reward_fn)
 
-        task = Task(message="What is 2+2?", context=TaskContext(ground_truth="4"))
+        task = Task(message="What is 2+2?", ground_truth="4")
         result = await env.rollout(task)
 
         reward_fn.compute.assert_awaited_once()
@@ -141,7 +140,7 @@ class TestRollout:
         ]
         mock_agent_cls.return_value = mock_agent(messages=history + new_messages)
 
-        task = Task(message="msg2", context=TaskContext(conversation_history=history))
+        task = Task(message="msg2", conversation_history=history)
         result = await env.rollout(task)
 
         assert len(result.messages) == 2

--- a/tests/unit/core/test_llm_judge_reward.py
+++ b/tests/unit/core/test_llm_judge_reward.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 from strands.types.exceptions import ModelThrottledException
 
 from strands_env.core.llm_judge_reward import LLMJudgeReward
-from strands_env.core.types import RolloutResult, Task, TaskContext
+from strands_env.core.types import RolloutResult, Task
 
 # ---------------------------------------------------------------------------
 # Concrete subclass for testing
@@ -57,7 +57,7 @@ class _TextJudge(LLMJudgeReward):
 
 
 def _task_and_result():
-    task = Task(message="What is 2+2?", context=TaskContext(ground_truth="4"))
+    task = Task(message="What is 2+2?", ground_truth="4")
     result = RolloutResult(
         messages=[{"role": "assistant", "content": [{"text": "4"}]}],
     )

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -25,28 +25,9 @@ from strands_env.core.types import (
     RewardResult,
     RolloutResult,
     Task,
-    TaskContext,
     TerminationReason,
     extract_message_text,
 )
-
-# ---------------------------------------------------------------------------
-# TaskContext
-# ---------------------------------------------------------------------------
-
-
-class TestTaskContext:
-    def test_defaults(self):
-        ctx = TaskContext()
-        assert ctx.ground_truth is None
-        assert ctx.conversation_history == []
-
-    def test_extra_fields(self):
-        ctx = TaskContext(ground_truth="42", difficulty=3, tags=["math"])
-        assert ctx.ground_truth == "42"
-        assert ctx.difficulty == 3
-        assert ctx.tags == ["math"]
-
 
 # ---------------------------------------------------------------------------
 # Task
@@ -57,12 +38,27 @@ class TestTask:
     def test_string_message(self):
         task = Task(message="What is 2+2?")
         assert task.message == "What is 2+2?"
-        assert task.context.ground_truth is None
+        assert task.ground_truth is None
+        assert task.conversation_history == []
 
-    def test_with_context(self):
-        ctx = TaskContext(ground_truth="4")
-        task = Task(message="What is 2+2?", context=ctx)
-        assert task.context.ground_truth == "4"
+    def test_ground_truth(self):
+        task = Task(message="What is 2+2?", ground_truth="4")
+        assert task.ground_truth == "4"
+
+    def test_extra_fields_allowed(self):
+        # ad-hoc tasks work without a subclass; extras survive JSON round-trips
+        task = Task(message="q", difficulty=3)
+        assert task.difficulty == 3
+        assert Task.model_validate_json(task.model_dump_json()).difficulty == 3
+
+    def test_subclass_json_round_trip(self):
+        class _MyTask(Task):
+            difficulty: int = 0
+
+        task = _MyTask(message="q", ground_truth="4", difficulty=3)
+        again = _MyTask.model_validate_json(task.model_dump_json())
+        assert again.ground_truth == "4"
+        assert again.difficulty == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/environments/calculator/test_math_verify_reward.py
+++ b/tests/unit/environments/calculator/test_math_verify_reward.py
@@ -14,7 +14,7 @@
 
 """Tests for MathVerifyReward."""
 
-from strands_env.core.types import RolloutResult, Task, TaskContext
+from strands_env.core.types import RolloutResult, Task
 from strands_env.environments.calculator.reward import MathVerifyReward
 
 
@@ -24,7 +24,7 @@ def make_rollout_result(content: str) -> RolloutResult:
 
 
 def make_task(ground_truth: str | None = None) -> Task:
-    return Task(message="test", context=TaskContext(ground_truth=ground_truth))
+    return Task(message="test", ground_truth=ground_truth)
 
 
 class TestMathRewardFunction:

--- a/tests/unit/eval/test_evaluator.py
+++ b/tests/unit/eval/test_evaluator.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from strands_sglang import Rollout
 
-from strands_env.core import RewardResult, RolloutResult, Task, TaskContext
+from strands_env.core import RewardResult, RolloutResult, Task
 from strands_env.eval import EvalSample, Evaluator
 from strands_env.eval.metrics import compute_pass_at_k
 
@@ -39,7 +39,7 @@ class TestEvaluator:
         async def factory(task):
             return mock_env
 
-        tasks = [Task(id=f"p{i}", message=f"q{i}", context=TaskContext()) for i in range(3)]
+        tasks = [Task(id=f"p{i}", message=f"q{i}") for i in range(3)]
 
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
         results = await evaluator.run(tasks)
@@ -57,7 +57,7 @@ class TestEvaluator:
         async def factory(task):
             return mock_env
 
-        tasks = [Task(id="p1", message="q", context=TaskContext())]
+        tasks = [Task(id="p1", message="q")]
 
         evaluator = Evaluator(env_factory=factory, n_samples_per_prompt=5, output_path=tmp_path / "results.jsonl")
         results = await evaluator.run(tasks)
@@ -147,7 +147,7 @@ class TestEvaluator:
             return env
 
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
-        results = await evaluator.run([Task(id="p1", message="q", context=TaskContext())])
+        results = await evaluator.run([Task(id="p1", message="q")])
 
         assert results["p1"][0].result.rollout is None
 
@@ -169,7 +169,7 @@ class TestEvaluator:
             return env
 
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
-        sample = await evaluator.evaluate_sample(Task(id="err", message="q", context=TaskContext()))
+        sample = await evaluator.evaluate_sample(Task(id="err", message="q"))
         assert sample.aborted
         assert cleanup_called
 
@@ -189,7 +189,7 @@ class TestCheckpoint:
             return mock_env
 
         evaluator = Evaluator(env_factory=factory, output_path=output_path, save_interval=1)
-        await evaluator.run([Task(id="s1", message="q1", context=TaskContext())])
+        await evaluator.run([Task(id="s1", message="q1")])
 
         assert output_path.exists()
         lines = output_path.read_text().strip().split("\n")
@@ -205,7 +205,7 @@ class TestCheckpoint:
 
         # First run - complete s1
         evaluator1 = Evaluator(env_factory=factory, output_path=output_path, save_interval=1)
-        await evaluator1.run([Task(id="s1", message="q1", context=TaskContext())])
+        await evaluator1.run([Task(id="s1", message="q1")])
         assert mock_env.rollout.await_count == 1
 
         # Second run - s1 skipped, s2 processed
@@ -213,8 +213,8 @@ class TestCheckpoint:
         evaluator2 = Evaluator(env_factory=factory, output_path=output_path, save_interval=1)
         results = await evaluator2.run(
             [
-                Task(id="s1", message="q1", context=TaskContext()),
-                Task(id="s2", message="q2", context=TaskContext()),
+                Task(id="s1", message="q1"),
+                Task(id="s2", message="q2"),
             ]
         )
 
@@ -267,14 +267,14 @@ class TestValidateSample:
 
         # First run
         eval1 = AbortingEvaluator(env_factory=factory, output_path=output_path, save_interval=1)
-        results1 = await eval1.run([Task(id="s1", message="q1", context=TaskContext())])
+        results1 = await eval1.run([Task(id="s1", message="q1")])
         assert rollout_count == 1
         assert results1["s1"][0].aborted is True
 
         # Second run — s1 retried
         rollout_count = 0
         eval2 = AbortingEvaluator(env_factory=factory, output_path=output_path, save_interval=1)
-        results2 = await eval2.run([Task(id="s1", message="q1", context=TaskContext())])
+        results2 = await eval2.run([Task(id="s1", message="q1")])
         assert rollout_count == 1
         assert results2["s1"][0].aborted is True
 
@@ -320,7 +320,7 @@ class TestValidateSample:
             max_concurrency=1,
             output_path=tmp_path / "results.jsonl",
         )
-        results = await evaluator.run([Task(id="p1", message="q", context=TaskContext())])
+        results = await evaluator.run([Task(id="p1", message="q")])
 
         assert len(results["p1"]) == 2
         aborted = [s for s in results["p1"] if s.aborted]
@@ -351,7 +351,7 @@ class TestComputeMetrics:
             return env
 
         evaluator = Evaluator(env_factory=factory, n_samples_per_prompt=3, output_path=tmp_path / "results.jsonl")
-        results = await evaluator.run([Task(id="p1", message="q", context=TaskContext())])
+        results = await evaluator.run([Task(id="p1", message="q")])
 
         metrics = evaluator.compute_metrics(results)
         assert "pass@1" in metrics
@@ -409,7 +409,7 @@ class TestPassAtK:
     def test_none_reward_handled(self):
         """Samples with None reward are treated as incorrect."""
         sample = EvalSample(
-            task=Task(id="p1_0", message="q", context=TaskContext()),
+            task=Task(id="p1_0", message="q"),
             result=RolloutResult(reward_result=None),
         )
         result = compute_pass_at_k({"p1": [sample]}, k_values=[1])
@@ -439,7 +439,7 @@ class TestDistributedEvaluation:
         mock_pool.rollout = AsyncMock(return_value=RolloutResult())
 
         evaluator = Evaluator(env_actor_pool=mock_pool, output_path=tmp_path / "results.jsonl")
-        results = await evaluator.run([Task(id="p1", message="q", context=TaskContext())])
+        results = await evaluator.run([Task(id="p1", message="q")])
 
         mock_pool.rollout.assert_awaited_once()
         assert len(results) == 1
@@ -455,7 +455,7 @@ class TestDistributedEvaluation:
             factory_called = True
 
         evaluator = Evaluator(env_factory=factory, env_actor_pool=mock_pool, output_path=tmp_path / "results.jsonl")
-        await evaluator.run([Task(id="p1", message="q", context=TaskContext())])
+        await evaluator.run([Task(id="p1", message="q")])
 
         assert not factory_called
 
@@ -465,7 +465,7 @@ class TestDistributedEvaluation:
         mock_pool.rollout = AsyncMock(side_effect=RuntimeError("remote error"))
 
         evaluator = Evaluator(env_actor_pool=mock_pool, output_path=tmp_path / "results.jsonl")
-        sample = await evaluator.evaluate_sample(Task(id="err", message="q", context=TaskContext()))
+        sample = await evaluator.evaluate_sample(Task(id="err", message="q"))
 
         assert sample.aborted
 
@@ -478,7 +478,7 @@ class TestDistributedEvaluation:
         mock_pool.rollout = AsyncMock(return_value=RolloutResult(rollout=rollout))
 
         evaluator = Evaluator(env_actor_pool=mock_pool, output_path=tmp_path / "results.jsonl")
-        results = await evaluator.run([Task(id="p1", message="q", context=TaskContext())])
+        results = await evaluator.run([Task(id="p1", message="q")])
 
         assert results["p1"][0].result.rollout is None
 


### PR DESCRIPTION
## Summary

First slice of the environment lifecycle v2 refactor (design: task data should enter through typed, declared fields — not an undeclared `context.config` escape hatch).

- `Task` is now flat: `ground_truth` and `conversation_history` move onto it; `TaskContext` is deleted.
- Per-sample payload gets a typed home: benchmarks/environments subclass `Task` with declared fields. The three former `TaskContext` subclasses convert directly (`Tau2BenchTask`, `TerminalBenchTask`, `MCPAtlasTask`) and the five `**extras` users become declared subclasses (`GPQATask`, `IFEvalTask`, `HLEVerifiedTask`, `SealQATask`, `FramesTask`) — metadata is validated instead of riding as untyped extras.
- The base keeps `extra="allow"`: ad-hoc tasks work without a subclass, and subclass fields survive base-`Task` (de)serialization at process boundaries; declared fields validate as usual either way.

## Breaking

- `TaskContext` is gone: `Task(message=..., context=TaskContext(ground_truth=...))` → `Task(message=..., ground_truth=...)`; all `task.context.X` reads become `task.X`.

## Test plan

- `pytest tests/unit/` — 204 passed; ruff/mypy clean.

Slice 1 of 7 — next: rollout template method, core generics, py3.12 floor, tau2/mcp-atlas payload migrations, eval None-reward policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)