### PR TITLE
refactor(core)!: rollout owns the episode lifecycle

### DIFF
--- a/examples/slime/retool/generate_with_agentcore_code.py
+++ b/examples/slime/retool/generate_with_agentcore_code.py
@@ -109,8 +109,6 @@ async def generate_and_rm(args, sample: Sample, sampling_params) -> Sample:
     sample.result = result
     sample.metrics = result.metrics
 
-    await env.cleanup()
-
     # Compute retool reward
     if result.reward_result.reward == 0.0:
         sample.reward = min(-0.6, -1 + (sample.metrics.get("tool_iters", 0) - 2) / 2 * 0.1)

--- a/examples/web_search_demo.py
+++ b/examples/web_search_demo.py
@@ -72,18 +72,15 @@ async def run_demo(
         verbose=False,
     )
 
-    try:
-        click.echo(f"\n{'=' * 60}")
-        click.echo(f"Question: {QUESTION}")
-        click.echo("-" * 60)
+    click.echo(f"\n{'=' * 60}")
+    click.echo(f"Question: {QUESTION}")
+    click.echo("-" * 60)
 
-        result = await env.rollout(Task(message=QUESTION))
+    result = await env.rollout(Task(message=QUESTION))
 
-        click.echo(f"\nMessages:    {result.messages}")
-        click.echo(f"\nTermination: {result.termination_reason.value}")
-        click.echo(f"Metrics:     {result.metrics}")
-    finally:
-        await env.cleanup()
+    click.echo(f"\nMessages:    {result.messages}")
+    click.echo(f"\nTermination: {result.termination_reason.value}")
+    click.echo(f"Metrics:     {result.metrics}")
 
 
 @click.command()

--- a/src/strands_env/core/distributed.py
+++ b/src/strands_env/core/distributed.py
@@ -62,12 +62,8 @@ class EnvironmentActor:
         """
         task = Task.model_validate_json(task_json)
         env = await self.env_factory(task)
-        try:
-            await env.reset()
-            result = await env.rollout(task)
-            return result.model_dump_json()
-        finally:
-            await env.cleanup()
+        result = await env.rollout(task)
+        return result.model_dump_json()
 
     async def compute_reward(self, task_json: str, result_json: str) -> str:
         """Recompute reward for an existing rollout without re-running the agent.

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -152,10 +152,7 @@ class Environment:
         # 3. Build the result.
         new_messages = list(agent.messages)[len(conversation_history) :]
         rollout = getattr(agent.model, "rollout", None)
-        tool_parse_errors = getattr(agent.model, "tool_parse_errors", None)
-        metrics = self.compute_metrics(
-            event_loop_metrics=agent.event_loop_metrics, loop_limiter=limiter, tool_parse_errors=tool_parse_errors
-        )
+        metrics = self.compute_metrics(agent, limiter)
         result = RolloutResult(
             messages=new_messages, rollout=rollout, metrics=metrics, termination_reason=termination_reason
         )
@@ -184,13 +181,16 @@ class Environment:
         """Conversation manager for context window handling. Override in subclasses."""
         return NullConversationManager()
 
-    def compute_metrics(
-        self,
-        event_loop_metrics: EventLoopMetrics,
-        loop_limiter: LoopLimiter,
-        tool_parse_errors: dict[str, int] | None = None,
-    ) -> dict[str, Any]:
-        """Extract metrics from the event loop. Override to add custom metrics."""
+    def compute_metrics(self, agent: Agent | None, loop_limiter: LoopLimiter) -> dict[str, Any]:
+        """Extract metrics from an agent's event loop. Override to add custom metrics.
+
+        `agent=None` means no agent ran (e.g. the episode ended before the first turn);
+        the metrics dict keeps its usual shape with zeroed values.
+        """
+        event_loop_metrics = agent.event_loop_metrics if agent is not None else EventLoopMetrics()
+        tool_parse_errors: dict[str, int] | None = (
+            getattr(agent.model, "tool_parse_errors", None) if agent is not None else None
+        )
 
         def _summarize(counts: Sequence[Any], round_digits: int = 1) -> dict[str, int | float]:
             return {

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -114,7 +114,9 @@ class Environment:
         """
         try:
             await self.reset(task)
-            return await self._rollout(task)
+            result = await self._rollout(task)
+            await self._compute_reward(task, result)
+            return result
         finally:
             await self.cleanup()
 
@@ -153,17 +155,17 @@ class Environment:
         new_messages = list(agent.messages)[len(conversation_history) :]
         rollout = getattr(agent.model, "rollout", None)
         metrics = self.compute_metrics(agent, limiter)
-        result = RolloutResult(
+        return RolloutResult(
             messages=new_messages, rollout=rollout, metrics=metrics, termination_reason=termination_reason
         )
 
-        # 4. Compute and time the reward (if any).
-        if self.reward_fn:
-            reward_t0 = time.perf_counter()
-            result.reward_result = await self.reward_fn.compute(task, result)
-            result.metrics["reward_latency_s"] = round(time.perf_counter() - reward_t0, 4)
-
-        return result
+    async def _compute_reward(self, task: Task, result: RolloutResult) -> None:
+        """Compute and time the reward (if any), recording `reward_latency_s` in the metrics."""
+        if self.reward_fn is None:
+            return
+        reward_t0 = time.perf_counter()
+        result.reward_result = await self.reward_fn.compute(task, result)
+        result.metrics["reward_latency_s"] = round(time.perf_counter() - reward_t0, 4)
 
     async def cleanup(self) -> None:
         """Release resources. Override in subclasses."""

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -91,20 +91,35 @@ class Environment:
         self.trace_attributes: dict[str, AttributeValue] | None = self.config.get("trace_attributes")
         self.agent_name: str | None = self.config.get("agent_name")
 
-    async def reset(self) -> None:
-        """Reset for a new episode. Override for environment-specific init.
+    async def reset(self, _task: Task) -> None:
+        """Build the episode for `task`. Override for environment-specific init.
+
+        Called by `rollout()` before the agent runs — gym-style, the task enters here.
 
         Notes:
             - This is the right place for resource-heavy or async initialization
             (e.g., spinning up containers, creating sessions, connecting to services).
-            - Keep `__init__` limited to storing config and lightweight state —
-            it is synchronous and cannot `await`.
-            - Paired with `cleanup` which tears down what `reset` sets up.
+            - Keep `__init__` limited to storing operator-authored config and lightweight
+            state — it is synchronous and cannot `await`.
+            - Paired with `cleanup`, which tears down what `reset` sets up and must
+            tolerate partially-initialized state (`reset` may fail midway).
         """
         pass
 
     async def rollout(self, task: Task) -> RolloutResult:
-        """Run one agent rollout and return its trajectory, reward, and termination reason."""
+        """Run one episode: `reset(task)`, then the agent loop, then `cleanup()` (always).
+
+        Template method — override `_rollout()` for environment-specific episode logic;
+        `rollout()` itself centralizes the setup/teardown guarantee for every harness.
+        """
+        try:
+            await self.reset(task)
+            return await self._rollout(task)
+        finally:
+            await self.cleanup()
+
+    async def _rollout(self, task: Task) -> RolloutResult:
+        """Run the agent loop for one episode and return its trajectory, reward, and termination reason."""
         # 1. Build inputs and the agent.
         conversation_history = task.conversation_history
         limiter = LoopLimiter(

--- a/src/strands_env/environments/agent_world_model/env.py
+++ b/src/strands_env/environments/agent_world_model/env.py
@@ -32,7 +32,7 @@ from typing_extensions import NotRequired, Unpack, override
 
 from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.core.models import ModelFactory
-from strands_env.core.types import RewardFunction
+from strands_env.core.types import RewardFunction, Task
 
 from .reward import AgentWorldModelReward
 from .server import kill_server, start_server
@@ -89,7 +89,7 @@ class AgentWorldModelEnv(Environment):
         self._tools: list[AgentWorldModelTool] = []
 
     @override
-    async def reset(self) -> None:
+    async def reset(self, task: Task) -> None:
         """Start AgentWorldModel server, open MCP session, discover tools."""
         await asyncio.sleep(random.uniform(0, 5))  # stagger concurrent server spawns
         self._server_proc, port = await start_server(

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -35,7 +35,7 @@ from harbor.models.trial.paths import TrialPaths
 from strands import tool
 from typing_extensions import NotRequired, TypedDict, Unpack, override
 
-from strands_env.core import Environment, ModelFactory
+from strands_env.core import Environment, ModelFactory, Task
 from strands_env.core.environment import EnvironmentConfig
 
 from .reward import HarborReward
@@ -106,7 +106,7 @@ class HarborEnv(Environment):
         self.reward_fn = HarborReward(self)
 
     @override
-    async def reset(self) -> None:
+    async def reset(self, task: Task) -> None:
         """Build and start the sandbox."""
         self.trial_paths.mkdir()
         session_id = f"{self.task_id}-{uuid.uuid4().hex[:8]}"

--- a/src/strands_env/environments/mcp_atlas/env.py
+++ b/src/strands_env/environments/mcp_atlas/env.py
@@ -25,7 +25,7 @@ from typing_extensions import Unpack, override
 
 from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.core.models import ModelFactory
-from strands_env.core.types import RewardFunction
+from strands_env.core.types import RewardFunction, Task
 
 from .tool import MCPAtlasTool
 
@@ -100,7 +100,7 @@ class MCPAtlasEnv(Environment):
         return httpx.AsyncClient(base_url=base_url, limits=limits)
 
     @override
-    async def reset(self) -> None:
+    async def reset(self, task: Task) -> None:
         """Fetch tools from the container (or use cache) and apply per-task filter."""
         if self._cached_tools is None:
             response = await self._http_client.post("/list-tools", timeout=self._tool_timeout)

--- a/src/strands_env/environments/tau2_bench/env.py
+++ b/src/strands_env/environments/tau2_bench/env.py
@@ -22,7 +22,6 @@ by `Tau2BenchUserSimulator` via `AfterInvocationEvent.resume` (strands-agents >=
 from __future__ import annotations
 
 import logging
-import time
 from typing import TYPE_CHECKING, Any, Literal
 
 from strands.types.content import Message
@@ -141,11 +140,7 @@ class Tau2BenchEnv(Environment):
                 metrics=self.compute_metrics(None, LoopLimiter()),
                 termination_reason=TerminationReason.TASK_COMPLETE,
             )
-            reward_t0 = time.perf_counter()
-            result.reward_result = await self.reward_fn.compute(task, result)
-            result.metrics["reward_latency_s"] = round(time.perf_counter() - reward_t0, 4)
             logger.warning("user ended the dialogue at greeting (%s...)", task.message[:80])
-        # otherwise, run the rollout normally (computes the reward itself)
         else:
             result = await super()._rollout(task)
 

--- a/src/strands_env/environments/tau2_bench/env.py
+++ b/src/strands_env/environments/tau2_bench/env.py
@@ -25,7 +25,6 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Literal
 
-from strands.telemetry.metrics import EventLoopMetrics
 from strands.types.content import Message
 from strands_sglang import LoopLimiter
 from typing_extensions import NotRequired, Unpack, override
@@ -138,7 +137,8 @@ class Tau2BenchEnv(Environment):
             result = RolloutResult(
                 messages=[{"role": "user", "content": [{"text": task.message}]}],
                 # A fresh limiter reports the truth: the agent loop processed nothing
-                metrics=self.compute_metrics(event_loop_metrics=EventLoopMetrics(), loop_limiter=LoopLimiter()),
+                # `agent=None`: the user stopped at the greeting, no assistant agent ever ran
+                metrics=self.compute_metrics(None, LoopLimiter()),
                 termination_reason=TerminationReason.TASK_COMPLETE,
             )
             reward_t0 = time.perf_counter()
@@ -153,11 +153,7 @@ class Tau2BenchEnv(Environment):
         result.metrics["user_simulator"] = {
             "termination": self.user_simulator.termination,
             "messages": list(self.user_simulator.agent.messages),
-            **self.compute_metrics(
-                event_loop_metrics=self.user_simulator.agent.event_loop_metrics,
-                loop_limiter=self.user_simulator.limiter,
-                tool_parse_errors=getattr(self.user_simulator.agent.model, "tool_parse_errors", None),
-            ),
+            **self.compute_metrics(self.user_simulator.agent, self.user_simulator.limiter),
         }
         return result
 

--- a/src/strands_env/environments/tau2_bench/env.py
+++ b/src/strands_env/environments/tau2_bench/env.py
@@ -98,7 +98,7 @@ class Tau2BenchEnv(Environment):
         self.reward_fn: Tau2BenchReward = Tau2BenchReward(env=self, judge_model=judge_model)
 
     @override
-    async def reset(self) -> None:
+    async def reset(self, task: Task) -> None:
         """Build the tau2 environment based on the task config."""
         self.tau2_task = _tau2.Tau2Task.model_validate(self.config["tau2_task"])
         self.tau2_env = _tau2.build_task_environment(self.domain, self.tau2_task)
@@ -125,7 +125,7 @@ class Tau2BenchEnv(Environment):
         )
 
     @override
-    async def rollout(self, task: Task) -> RolloutResult:
+    async def _rollout(self, task: Task) -> RolloutResult:
         """Seed the greeting exchange into the task, then run the episode."""
         # task prompt is simulated by the user simulator
         task.message = await self.user_simulator.first_message()
@@ -147,7 +147,7 @@ class Tau2BenchEnv(Environment):
             logger.warning("user ended the dialogue at greeting (%s...)", task.message[:80])
         # otherwise, run the rollout normally (computes the reward itself)
         else:
-            result = await super().rollout(task)
+            result = await super()._rollout(task)
 
         # both paths report the user-simulator's side of the episode
         result.metrics["user_simulator"] = {

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -170,11 +170,7 @@ class Evaluator:
             else:
                 assert self.env_factory is not None
                 env = await self.env_factory(task)
-                try:
-                    await env.reset()
-                    result = await env.rollout(task)
-                finally:
-                    await env.cleanup()
+                result = await env.rollout(task)
             # Clean up the token-level rollout if not needed to reduce verbosity
             if not self.keep_rollout:
                 result.rollout = None

--- a/tests/integration/test_agentcore_code.py
+++ b/tests/integration/test_agentcore_code.py
@@ -49,11 +49,9 @@ def agentcore_client():
 
 
 @pytest.fixture
-async def code_env(model_factory, agentcore_client):
-    """AgentCoreCodeEnv in CODE mode with automatic cleanup."""
-    env = AgentCoreCodeEnv(model_factory=model_factory, client=agentcore_client, mode="code")
-    yield env
-    await env.cleanup()
+def code_env(model_factory, agentcore_client):
+    """AgentCoreCodeEnv in CODE mode; rollout() cleans up its session per episode."""
+    return AgentCoreCodeEnv(model_factory=model_factory, client=agentcore_client, mode="code")
 
 
 # ---------------------------------------------------------------------------
@@ -76,22 +74,16 @@ class TestAgentCoreCodeEnv:
     async def test_terminal_mode(self, model_factory, agentcore_client):
         """TERMINAL mode: agent executes shell commands."""
         env = AgentCoreCodeEnv(model_factory=model_factory, client=agentcore_client, mode="terminal")
-        try:
-            result = await env.rollout(Task(message="Use a shell command to print 'hello' with echo."))
-            assert_successful_rollout(result)
-        finally:
-            await env.cleanup()
+        result = await env.rollout(Task(message="Use a shell command to print 'hello' with echo."))
+        assert_successful_rollout(result)
 
     async def test_code_and_terminal_mode(self, model_factory, agentcore_client):
         """CODE_AND_TERMINAL mode: both execute_code and execute_command tools available."""
         env = AgentCoreCodeEnv(model_factory=model_factory, client=agentcore_client, mode="code_and_terminal")
-        try:
-            result = await env.rollout(
-                Task(message="Use code to compute 2 + 2, then use a shell command to echo the result."),
-            )
-            assert_successful_rollout(result)
-        finally:
-            await env.cleanup()
+        result = await env.rollout(
+            Task(message="Use code to compute 2 + 2, then use a shell command to echo the result."),
+        )
+        assert_successful_rollout(result)
 
     async def test_multi_turn_with_reward(self, model_factory, agentcore_client):
         """Multi-turn conversation with reward function exercising the full lifecycle."""
@@ -108,22 +100,19 @@ class TestAgentCoreCodeEnv:
             mode="code",
             reward_fn=ContainsReward(),
         )
-        try:
-            result1 = await env.rollout(Task(message="Use code to define x = 42 and print it."))
-            assert result1.termination_reason == TerminationReason.TASK_COMPLETE
+        result1 = await env.rollout(Task(message="Use code to define x = 42 and print it."))
+        assert result1.termination_reason == TerminationReason.TASK_COMPLETE
 
-            result2 = await env.rollout(
-                Task(
-                    message="Now use code to compute x * 2 and give me the final number.",
-                    conversation_history=result1.messages,
-                    ground_truth=84,
-                ),
-            )
-            assert result2.termination_reason == TerminationReason.TASK_COMPLETE
-            assert result2.reward_result is not None
-            assert isinstance(result2.reward_result.reward, float)
-        finally:
-            await env.cleanup()
+        result2 = await env.rollout(
+            Task(
+                message="Now use code to compute x * 2 and give me the final number.",
+                conversation_history=result1.messages,
+                ground_truth=84,
+            ),
+        )
+        assert result2.termination_reason == TerminationReason.TASK_COMPLETE
+        assert result2.reward_result is not None
+        assert isinstance(result2.reward_result.reward, float)
 
     async def test_tool_iteration_limit(self, model_factory, agentcore_client):
         """max_tool_iters terminates the agent after the specified number of tool rounds."""
@@ -134,13 +123,10 @@ class TestAgentCoreCodeEnv:
             system_prompt=FORCE_TOOL_PROMPT,
             max_tool_iters=1,
         )
-        try:
-            result = await env.rollout(Task(message=MANY_STEPS_PROMPT))
+        result = await env.rollout(Task(message=MANY_STEPS_PROMPT))
 
-            assert result.termination_reason == TerminationReason.MAX_TOOL_ITERATIONS_REACHED
-            assert result.metrics["tool_iters"] <= 1
-        finally:
-            await env.cleanup()
+        assert result.termination_reason == TerminationReason.MAX_TOOL_ITERATIONS_REACHED
+        assert result.metrics["tool_iters"] <= 1
 
     async def test_max_tool_calls_limit(self, model_factory, agentcore_client):
         """max_tool_calls terminates the agent after the specified total tool invocations."""
@@ -151,10 +137,7 @@ class TestAgentCoreCodeEnv:
             system_prompt=FORCE_TOOL_PROMPT,
             max_tool_calls=1,
         )
-        try:
-            result = await env.rollout(Task(message=MANY_STEPS_PROMPT))
+        result = await env.rollout(Task(message=MANY_STEPS_PROMPT))
 
-            assert result.termination_reason == TerminationReason.MAX_TOOL_CALLS_REACHED
-            assert result.metrics["tool_calls"] >= 1
-        finally:
-            await env.cleanup()
+        assert result.termination_reason == TerminationReason.MAX_TOOL_CALLS_REACHED
+        assert result.metrics["tool_calls"] >= 1

--- a/tests/integration/test_harbor.py
+++ b/tests/integration/test_harbor.py
@@ -77,17 +77,14 @@ def task_dir(tmp_path_factory, docker_available):
 
 
 @pytest.fixture
-async def harbor_env(model_factory, task_dir, tmp_path):
-    """HarborEnv with Docker reset and cleanup."""
-    env = HarborEnv(
+def harbor_env(model_factory, task_dir, tmp_path):
+    """HarborEnv — each rollout() builds and tears down its own sandbox."""
+    return HarborEnv(
         model_factory=model_factory,
         task_id="test-task",
         task_dir=str(task_dir),
         trial_dir=str(tmp_path / "trial"),
     )
-    await env.reset()
-    yield env
-    await env.cleanup()
 
 
 # ---------------------------------------------------------------------------
@@ -133,14 +130,10 @@ class TestHarborEnv:
             system_prompt=FORCE_TOOL_PROMPT,
             max_tool_iters=1,
         )
-        try:
-            await env.reset()
-            result = await env.rollout(Task(message=MANY_STEPS_PROMPT))
+        result = await env.rollout(Task(message=MANY_STEPS_PROMPT))
 
-            assert result.termination_reason == TerminationReason.MAX_TOOL_ITERATIONS_REACHED
-            assert result.metrics["tool_iters"] <= 1
-        finally:
-            await env.cleanup()
+        assert result.termination_reason == TerminationReason.MAX_TOOL_ITERATIONS_REACHED
+        assert result.metrics["tool_iters"] <= 1
 
     async def test_max_tool_calls_limit(self, model_factory, task_dir, tmp_path):
         """max_tool_calls terminates the agent after the specified total tool invocations."""
@@ -152,11 +145,7 @@ class TestHarborEnv:
             system_prompt=FORCE_TOOL_PROMPT,
             max_tool_calls=1,
         )
-        try:
-            await env.reset()
-            result = await env.rollout(Task(message=MANY_STEPS_PROMPT))
+        result = await env.rollout(Task(message=MANY_STEPS_PROMPT))
 
-            assert result.termination_reason == TerminationReason.MAX_TOOL_CALLS_REACHED
-            assert result.metrics["tool_calls"] >= 1
-        finally:
-            await env.cleanup()
+        assert result.termination_reason == TerminationReason.MAX_TOOL_CALLS_REACHED
+        assert result.metrics["tool_calls"] >= 1

--- a/tests/integration/test_web_search.py
+++ b/tests/integration/test_web_search.py
@@ -41,41 +41,32 @@ class TestSerperWebSearchEnv:
     async def test_search_completes_with_response(self, model_factory):
         """Agent searches the web, produces a response, and reports metrics."""
         env = WebSearchEnv(model_factory=model_factory)
-        try:
-            result = await env.rollout(Task(message="What is the capital of France?"))
+        result = await env.rollout(Task(message="What is the capital of France?"))
 
-            assert_successful_rollout(result)
-            assert result.metrics["model_calls"] >= 1
-        finally:
-            await env.cleanup()
+        assert_successful_rollout(result)
+        assert result.metrics["model_calls"] >= 1
 
     async def test_search_and_scrape(self, model_factory):
         """Agent can search and scrape pages when scrape_config is provided."""
         env = WebSearchEnv(model_factory=model_factory, scrape_enabled=True)
-        try:
-            result = await env.rollout(Task(message="What is the population of Tokyo?"))
-            assert_successful_rollout(result)
-        finally:
-            await env.cleanup()
+        result = await env.rollout(Task(message="What is the population of Tokyo?"))
+        assert_successful_rollout(result)
 
     async def test_tool_iteration_limit(self, model_factory):
         """max_tool_iters constrains the search agent."""
         env = WebSearchEnv(model_factory=model_factory, max_tool_iters=1)
-        try:
-            result = await env.rollout(
-                Task(
-                    message=(
-                        "Search for 10 different topics: Python, Java, Rust, Go, C++, "
-                        "Ruby, PHP, Swift, Kotlin, Scala. Search each one separately."
-                    )
-                ),
-            )
-            assert result.termination_reason in (
-                TerminationReason.MAX_TOOL_ITERATIONS_REACHED,
-                TerminationReason.TASK_COMPLETE,
-            )
-        finally:
-            await env.cleanup()
+        result = await env.rollout(
+            Task(
+                message=(
+                    "Search for 10 different topics: Python, Java, Rust, Go, C++, "
+                    "Ruby, PHP, Swift, Kotlin, Scala. Search each one separately."
+                )
+            ),
+        )
+        assert result.termination_reason in (
+            TerminationReason.MAX_TOOL_ITERATIONS_REACHED,
+            TerminationReason.TASK_COMPLETE,
+        )
 
 
 @google_available
@@ -83,8 +74,5 @@ class TestGoogleWebSearchEnv:
     async def test_search_completes_with_response(self, model_factory):
         """Agent can search with Google Custom Search and produce a response."""
         env = WebSearchEnv(model_factory=model_factory, search_provider="google")
-        try:
-            result = await env.rollout(Task(message="What is the speed of light?"))
-            assert_successful_rollout(result)
-        finally:
-            await env.cleanup()
+        result = await env.rollout(Task(message="What is the speed of light?"))
+        assert_successful_rollout(result)

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -175,6 +175,49 @@ class TestRollout:
 
 
 # ---------------------------------------------------------------------------
+# rollout() template method
+# ---------------------------------------------------------------------------
+
+
+class TestRolloutTemplate:
+    async def test_reset_receives_task_and_cleanup_always_runs(self, env):
+        """rollout() = reset(task) -> _rollout(task) -> cleanup(), cleanup even on error."""
+        calls = []
+        task = Task(message="q")
+
+        async def reset(t):
+            calls.append(("reset", t))
+
+        async def _rollout(t):
+            calls.append(("_rollout", t))
+            raise RuntimeError("episode failed")
+
+        async def cleanup():
+            calls.append(("cleanup", None))
+
+        env.reset, env._rollout, env.cleanup = reset, _rollout, cleanup
+        with pytest.raises(RuntimeError):
+            await env.rollout(task)
+
+        assert calls == [("reset", task), ("_rollout", task), ("cleanup", None)]
+
+    async def test_cleanup_runs_when_reset_fails(self, env):
+        """A midway reset failure still triggers cleanup (which must tolerate partial init)."""
+        cleaned = []
+
+        async def reset(t):
+            raise RuntimeError("reset failed")
+
+        async def cleanup():
+            cleaned.append(True)
+
+        env.reset, env.cleanup = reset, cleanup
+        with pytest.raises(RuntimeError):
+            await env.rollout(Task(message="q"))
+        assert cleaned == [True]
+
+
+# ---------------------------------------------------------------------------
 # compute_metrics()
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -224,6 +224,14 @@ class TestRolloutTemplate:
 
 class TestComputeMetrics:
     @staticmethod
+    def _agent(metrics, tool_parse_errors=None):
+        """Agent-shaped mock: compute_metrics reads .event_loop_metrics and .model.tool_parse_errors."""
+        agent = MagicMock()
+        agent.event_loop_metrics = metrics
+        agent.model.tool_parse_errors = tool_parse_errors
+        return agent
+
+    @staticmethod
     def _make_cycle(input_tokens, output_tokens, cache_read_input_tokens=0):
         cycle = MagicMock()
         cycle.usage = {
@@ -240,7 +248,7 @@ class TestComputeMetrics:
         metrics.agent_invocations[0].cycles = cycles
         metrics.cycle_durations = [0.8, 0.9, 0.8]
 
-        result = env.compute_metrics(metrics, LoopLimiter())
+        result = env.compute_metrics(self._agent(metrics), LoopLimiter())
 
         assert result["model_calls"] == 3
         assert result["input_tokens"]["total"] == 100
@@ -260,7 +268,7 @@ class TestComputeMetrics:
         metrics.cycle_durations = [0.5]
         metrics.tool_metrics = {"calculator": tool_metric}
 
-        result = env.compute_metrics(metrics, LoopLimiter(), tool_parse_errors={"calculator": 2})
+        result = env.compute_metrics(self._agent(metrics, tool_parse_errors={"calculator": 2}), LoopLimiter())
 
         assert result["per_tool_metrics"]["calculator"]["calls"] == 5
         assert result["per_tool_metrics"]["calculator"]["successes"] == 4
@@ -276,7 +284,7 @@ class TestComputeMetrics:
         metrics.agent_invocations[0].cycles = cycles
         metrics.cycle_durations = [0.5]
 
-        result = env.compute_metrics(metrics, LoopLimiter())
+        result = env.compute_metrics(self._agent(metrics), LoopLimiter())
 
         assert result["cache_hit_rate"] == pytest.approx(0.4)
         assert result["cache_read_input_tokens"]["total"] == 40
@@ -289,7 +297,7 @@ class TestComputeMetrics:
         metrics.agent_invocations[0].cycles = cycles
         metrics.cycle_durations = [0.5]
 
-        result = env.compute_metrics(metrics, LoopLimiter())
+        result = env.compute_metrics(self._agent(metrics), LoopLimiter())
 
         # any(cache_read_counts) is False when all are 0 → no summary
         assert result["cache_read_input_tokens"] is None
@@ -301,7 +309,7 @@ class TestComputeMetrics:
         metrics.agent_invocations = []
         metrics.cycle_durations = []
 
-        result = env.compute_metrics(metrics, LoopLimiter())
+        result = env.compute_metrics(self._agent(metrics), LoopLimiter())
 
         assert result["cache_hit_rate"] is None
 

--- a/tests/unit/eval/test_evaluator.py
+++ b/tests/unit/eval/test_evaluator.py
@@ -33,7 +33,7 @@ from ..conftest import make_sample
 
 class TestEvaluator:
     async def test_factory_mode(self, mock_env, tmp_path):
-        """Factory mode: reset/rollout/cleanup called for each sample."""
+        """Factory mode: rollout() called once per sample (it owns reset/cleanup internally)."""
         mock_env.rollout.return_value = RolloutResult()
 
         async def factory(task):
@@ -44,9 +44,7 @@ class TestEvaluator:
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
         results = await evaluator.run(tasks)
 
-        assert mock_env.reset.await_count == 3
         assert mock_env.rollout.await_count == 3
-        assert mock_env.cleanup.await_count == 3
         assert len(results) == 3
         assert sum(len(samples) for samples in results.values()) == 3
 
@@ -151,27 +149,17 @@ class TestEvaluator:
 
         assert results["p1"][0].result.rollout is None
 
-    async def test_cleanup_called_on_rollout_error(self, tmp_path):
-        """env.cleanup() is called even when env.rollout() raises."""
-        cleanup_called = False
+    async def test_rollout_error_aborts_sample(self, tmp_path):
+        """A raising rollout() marks the sample aborted (cleanup guarantee lives in Environment.rollout)."""
 
         async def factory(task):
-            nonlocal cleanup_called
             env = MagicMock()
-            env.reset = AsyncMock()
             env.rollout = AsyncMock(side_effect=RuntimeError("rollout failed"))
-
-            async def track_cleanup():
-                nonlocal cleanup_called
-                cleanup_called = True
-
-            env.cleanup = track_cleanup
             return env
 
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
         sample = await evaluator.evaluate_sample(Task(id="err", message="q"))
         assert sample.aborted
-        assert cleanup_called
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 2 of the lifecycle v2 refactor: `rollout(task)` becomes a template method owning the whole episode.

```python
try:
    await self.reset(task)                     # task enters gym-style, at the episode boundary
    result = await self._rollout(task)         # overridable episode logic
    await self._compute_reward(task, result)   # timed uniformly; before cleanup (rewards may need live state)
    return result
finally:
    await self.cleanup()                       # guaranteed, even on mid-reset failure
```

- `reset()` gains the `task` parameter; episode logic moves to the overridable `_rollout()`.
- The try/finally teardown guarantee was duplicated across three harness call sites (`Evaluator.evaluate_sample`, `EnvironmentActor.rollout`, downstream RL generate loops) — it now lives in one place; harnesses just call `rollout(task)`.
- Reward is a template stage: `_rollout` only produces the trajectory; judging runs for every path (tau2's greeting short-circuit drops its hand-copied timing block), and reward-before-cleanup ordering is enforced by the template.
- `compute_metrics(agent, loop_limiter)` derives event-loop metrics and tool parse errors from the agent itself (`agent=None` = no agent ran, zeroed shape); the limiter stays a parameter because `HookRegistry` is write-only.

## Breaking

- Overriding envs implement `reset(self, task)` / `_rollout(self, task)` instead of `reset(self)` / `rollout(self, task)`.
- Harnesses must not call `reset()`/`cleanup()` around `rollout()` anymore.
- Sessions no longer persist across rollouts on a reused env instance (cleanup runs per episode), matching the env-per-sample contract.

## Test plan

- 206 unit tests passed (new `TestRolloutTemplate` covers reset-receives-task, cleanup-on-error, cleanup-on-reset-failure); ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)