### PR TITLE
feat(core): parameterize Environment and RewardFunction over the task type

### DIFF
--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -20,7 +20,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import Any, ClassVar, TypeAlias
+from typing import Any, ClassVar, Generic, TypeAlias
 
 from opentelemetry.util.types import AttributeValue
 from strands import Agent
@@ -34,14 +34,14 @@ from .models import ModelFactory
 from .types import (
     RewardFunction,
     RolloutResult,
-    Task,
+    TaskT,
     TerminationReason,
 )
 
 logger = logging.getLogger(__name__)
 
 #: Type alias for environment factory function (async).
-AsyncEnvFactory: TypeAlias = Callable[[Any], Awaitable["Environment"]]
+AsyncEnvFactory: TypeAlias = Callable[[Any], Awaitable["Environment[Any]"]]
 
 
 class EnvironmentConfig(TypedDict, total=False):
@@ -60,7 +60,7 @@ class EnvironmentConfig(TypedDict, total=False):
     verbose: bool
 
 
-class Environment:
+class Environment(Generic[TaskT]):
     """Base RL rollout environment for Strands agents."""
 
     default_system_prompt_path: ClassVar[Path | None] = None
@@ -69,7 +69,7 @@ class Environment:
         self,
         *,
         model_factory: ModelFactory,
-        reward_fn: RewardFunction | None = None,
+        reward_fn: RewardFunction[TaskT] | None = None,
         **config: Unpack[EnvironmentConfig],
     ):
         """Initialize an `Environment` instance."""
@@ -91,7 +91,7 @@ class Environment:
         self.trace_attributes: dict[str, AttributeValue] | None = self.config.get("trace_attributes")
         self.agent_name: str | None = self.config.get("agent_name")
 
-    async def reset(self, _task: Task) -> None:
+    async def reset(self, _task: TaskT) -> None:
         """Build the episode for `task`. Override for environment-specific init.
 
         Called by `rollout()` before the agent runs — gym-style, the task enters here.
@@ -106,7 +106,7 @@ class Environment:
         """
         pass
 
-    async def rollout(self, task: Task) -> RolloutResult:
+    async def rollout(self, task: TaskT) -> RolloutResult:
         """Run one episode: `reset(task)`, then the agent loop, then `cleanup()` (always).
 
         Template method — override `_rollout()` for environment-specific episode logic;
@@ -120,7 +120,7 @@ class Environment:
         finally:
             await self.cleanup()
 
-    async def _rollout(self, task: Task) -> RolloutResult:
+    async def _rollout(self, task: TaskT) -> RolloutResult:
         """Run the agent loop for one episode and return its trajectory, reward, and termination reason."""
         # 1. Build inputs and the agent.
         conversation_history = task.conversation_history
@@ -159,7 +159,7 @@ class Environment:
             messages=new_messages, rollout=rollout, metrics=metrics, termination_reason=termination_reason
         )
 
-    async def _compute_reward(self, task: Task, result: RolloutResult) -> None:
+    async def _compute_reward(self, task: TaskT, result: RolloutResult) -> None:
         """Compute and time the reward (if any), recording `reward_latency_s` in the metrics."""
         if self.reward_fn is None:
             return

--- a/src/strands_env/core/llm_judge_reward.py
+++ b/src/strands_env/core/llm_judge_reward.py
@@ -19,15 +19,15 @@ from __future__ import annotations
 import itertools
 import logging
 from abc import abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic
 
 from pydantic import BaseModel
 from strands import Agent
 from strands.models import Model
 from strands.types.exceptions import ModelThrottledException
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
-from .types import RewardFunction, RewardResult, RolloutResult, Task
+from .types import RewardFunction, RewardResult, RolloutResult, TaskT
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 JudgmentFormat = TypeVar("JudgmentFormat", bound=BaseModel)
 
 
-class LLMJudgeReward(RewardFunction, Generic[JudgmentFormat]):
+class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
     r"""Abstract base for LLM-as-judge reward functions.
 
     Args:
@@ -58,7 +58,7 @@ class LLMJudgeReward(RewardFunction, Generic[JudgmentFormat]):
         class SimpleQAReward(LLMJudgeReward[SimpleQAJudgment]):
             judgment_format = SimpleQAJudgment
 
-            async def get_judge_prompt(self, task: Task, result: RolloutResult) -> str:
+            async def get_judge_prompt(self, task: TaskT, result: RolloutResult) -> str:
                 return f"Question: {task.message}\\nAnswer: {result.final_response}"
 
             async def get_reward(self, judgment: SimpleQAJudgment | str) -> float:
@@ -83,7 +83,7 @@ class LLMJudgeReward(RewardFunction, Generic[JudgmentFormat]):
         self.max_model_retries = max_model_retries
 
     @abstractmethod
-    async def get_judge_prompt(self, task: Task, result: RolloutResult) -> str:
+    async def get_judge_prompt(self, task: TaskT, result: RolloutResult) -> str:
         """Format the prompt for the judge model."""
         raise NotImplementedError("Subclasses must implement this method.")
 
@@ -93,7 +93,7 @@ class LLMJudgeReward(RewardFunction, Generic[JudgmentFormat]):
         raise NotImplementedError("Subclasses must implement this method.")
 
     @override
-    async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
+    async def compute(self, task: TaskT, result: RolloutResult) -> RewardResult:
         try:
             prompt = await self.get_judge_prompt(task, result)
         except Exception as e:

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -20,12 +20,13 @@ import logging
 import uuid
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any
+from typing import Any, Generic
 
 from pydantic import BaseModel, ConfigDict, Field
 from strands.types.content import Message, Messages
 from strands.types.exceptions import ContextWindowOverflowException, EventLoopException, MaxTokensReachedException
 from strands_sglang import MaxMessagesReachedError, MaxToolCallsReachedError, MaxToolIterationsReachedError, Rollout
+from typing_extensions import TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,10 @@ class Task(BaseModel):
     conversation_history: Messages = Field(default_factory=list, description="The conversation prior to the task.")
 
 
+#: The task type an environment (or reward function) consumes. Defaults to `Task` (PEP 696),
+TaskT = TypeVar("TaskT", bound=Task, default=Task)
+
+
 # ---------------------------------------------------------------------------
 # Reward (for a rollout)
 # ---------------------------------------------------------------------------
@@ -62,11 +67,11 @@ class RewardResult(BaseModel):
     info: dict[str, Any] = Field(default_factory=dict, description="Additional diagnostic information.")
 
 
-class RewardFunction(ABC):
+class RewardFunction(ABC, Generic[TaskT]):
     """Abstract reward function. Subclass and implement `compute`."""
 
     @abstractmethod
-    async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
+    async def compute(self, task: TaskT, result: RolloutResult) -> RewardResult:
         """Return a `RewardResult` given the task and the rollout result."""
         ...
 


### PR DESCRIPTION
## Summary

Slice 3: `TaskT = TypeVar(bound=Task, default=Task)` (PEP 696 via typing_extensions).

- `Environment(Generic[TaskT])`: typed `reset`/`rollout`/`_rollout`/`_compute_reward` signatures, and mypy now enforces the env↔reward task coupling (`reward_fn: RewardFunction[TaskT]`).
- `RewardFunction(ABC, Generic[TaskT])`; `LLMJudgeReward` grows the task parameter second (`LLMJudgeReward[JudgmentFormat, TaskT]`) so existing single-parameter judges keep working via the default.
- Unparameterized subclasses keep meaning `Environment[Task]` / `RewardFunction[Task]` — zero changes required for existing environments (verified: the whole tree stays green with no env parameterized).

Boundary note: generics erase at runtime and the harness seam stays `Environment[Any]` (TaskT is invariant); static safety covers the env module's interior. The process-boundary path is completed by the runtime `task_cls` upcast in a later slice.

## Test plan

- 206 unit tests passed; mypy strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)