### PR TITLE
build!: require Python 3.12, test on 3.12 and 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "strands-env"
 dynamic = ["version"]
 description = "A framework for building agent environments with Strands Agents."
 authors = [{name = "Yuan He", email = "yuanhe.cs.ai@gmail.com"}]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 classifiers = [
@@ -51,11 +51,11 @@ dev = [
 ]
 litellm = ["litellm"]
 harbor = [
-    "harbor>=0.14.0; python_version>='3.12'",
+    "harbor>=0.14.0",
     "e2b==2.25.1",
 ]
 ifeval = ["lm_eval[ifeval]>=0.4.11"]
-agent-world-model = ["agent-world-model==0.1.0; python_version>='3.12'"]
+agent-world-model = ["agent-world-model==0.1.0"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -20,7 +20,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import Any, ClassVar, Generic, TypeAlias
+from typing import Any, ClassVar, Generic, Unpack
 
 from opentelemetry.util.types import AttributeValue
 from strands import Agent
@@ -28,7 +28,7 @@ from strands.agent.conversation_manager import ConversationManager, NullConversa
 from strands.handlers.callback_handler import PrintingCallbackHandler
 from strands.telemetry.metrics import EventLoopMetrics
 from strands_sglang import LoopLimiter
-from typing_extensions import TypedDict, Unpack
+from typing_extensions import TypedDict
 
 from .models import ModelFactory
 from .types import (
@@ -41,7 +41,7 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 #: Type alias for environment factory function (async).
-AsyncEnvFactory: TypeAlias = Callable[[Any], Awaitable["Environment[Any]"]]
+type AsyncEnvFactory = Callable[[Any], Awaitable["Environment[Any]"]]
 
 
 class EnvironmentConfig(TypedDict, total=False):
@@ -60,7 +60,7 @@ class EnvironmentConfig(TypedDict, total=False):
     verbose: bool
 
 
-class Environment(Generic[TaskT]):
+class Environment(Generic[TaskT]):  # noqa: UP046 — PEP 695 syntax can't express TaskT's default until 3.13
     """Base RL rollout environment for Strands agents."""
 
     default_system_prompt_path: ClassVar[Path | None] = None

--- a/src/strands_env/core/llm_judge_reward.py
+++ b/src/strands_env/core/llm_judge_reward.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 import itertools
 import logging
 from abc import abstractmethod
-from typing import Generic
+from typing import Generic, override
 
 from pydantic import BaseModel
 from strands import Agent
 from strands.models import Model
 from strands.types.exceptions import ModelThrottledException
-from typing_extensions import TypeVar, override
+from typing_extensions import TypeVar
 
 from .types import RewardFunction, RewardResult, RolloutResult, TaskT
 
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 JudgmentFormat = TypeVar("JudgmentFormat", bound=BaseModel)
 
 
-class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
+class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):  # noqa: UP046 — see Environment
     r"""Abstract base for LLM-as-judge reward functions.
 
     Args:

--- a/src/strands_env/core/mcp_tool.py
+++ b/src/strands_env/core/mcp_tool.py
@@ -22,11 +22,10 @@ the Strands agent interface.  It handles tool spec building; subclasses implemen
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, override
 
 from strands.tools.tools import AgentTool, ToolResultEvent
 from strands.types.tools import ToolGenerator, ToolResult, ToolResultContent, ToolSpec, ToolUse
-from typing_extensions import override
 
 if TYPE_CHECKING:
     from mcp.types import Tool as MCPToolDef

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 import uuid
 from abc import ABC, abstractmethod
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Generic
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -81,7 +81,7 @@ class RewardFunction(ABC, Generic[TaskT]):
 # ---------------------------------------------------------------------------
 
 
-class TerminationReason(str, Enum):
+class TerminationReason(StrEnum):
     """Why an episode ended."""
 
     NOT_TERMINATED = "not_terminated"

--- a/src/strands_env/environments/agent_world_model/env.py
+++ b/src/strands_env/environments/agent_world_model/env.py
@@ -24,11 +24,11 @@ import shutil
 import subprocess
 from datetime import timedelta
 from pathlib import Path
+from typing import NotRequired, Unpack, override
 
 import httpx
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
-from typing_extensions import NotRequired, Unpack, override
 
 from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.core.models import ModelFactory

--- a/src/strands_env/environments/agent_world_model/tool.py
+++ b/src/strands_env/environments/agent_world_model/tool.py
@@ -18,13 +18,12 @@ from __future__ import annotations
 
 import subprocess
 from datetime import timedelta
-from typing import Any, Literal
+from typing import Any, Literal, override
 
 from mcp import ClientSession
 from mcp.types import TextContent
 from mcp.types import Tool as MCPToolDef
 from strands.types.tools import ToolResultContent
-from typing_extensions import override
 
 from strands_env.core.mcp_tool import MCPToolAdapter
 

--- a/src/strands_env/environments/agentcore_code/env.py
+++ b/src/strands_env/environments/agentcore_code/env.py
@@ -17,9 +17,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
-
-from typing_extensions import Unpack, override
+from typing import TYPE_CHECKING, Literal, Unpack, override
 
 from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.utils.aws import get_client

--- a/src/strands_env/environments/calculator/env.py
+++ b/src/strands_env/environments/calculator/env.py
@@ -15,9 +15,9 @@
 """Simple math environment using a calculator tool."""
 
 from pathlib import Path
+from typing import Unpack, override
 
 from strands_tools.calculator import calculator
-from typing_extensions import Unpack, override
 
 from strands_env.core import Environment, EnvironmentConfig, ModelFactory, RewardFunction
 from strands_env.environments.calculator.reward import MathVerifyReward

--- a/src/strands_env/environments/calculator/reward.py
+++ b/src/strands_env/environments/calculator/reward.py
@@ -17,10 +17,9 @@ r"""Reward function for math problems using HuggingFace's `math-verify` for symb
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from math_verify import ExprExtractionConfig, LatexExtractionConfig, parse, verify
-from typing_extensions import override
 
 from strands_env.core.types import RewardFunction, RewardResult, RolloutResult, Task
 from strands_env.utils.decorators import with_timeout

--- a/src/strands_env/environments/harbor/e2b.py
+++ b/src/strands_env/environments/harbor/e2b.py
@@ -24,13 +24,12 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 import e2b.api as _e2b_api
 from e2b.exceptions import AuthenticationException
 from harbor.environments.e2b import E2BEnvironment
 from harbor.models.trial.paths import EnvironmentPaths
-from typing_extensions import override
 
 if TYPE_CHECKING:
     from .env import PrebakedE2BConfig

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, NotRequired, Unpack, override
 
 from harbor.environments.factory import EnvironmentFactory
 from harbor.models.environment_type import EnvironmentType
@@ -33,7 +33,7 @@ from harbor.models.task.config import EnvironmentConfig as TaskEnvironmentConfig
 from harbor.models.task.paths import TaskPaths
 from harbor.models.trial.paths import TrialPaths
 from strands import tool
-from typing_extensions import NotRequired, TypedDict, Unpack, override
+from typing_extensions import TypedDict
 
 from strands_env.core import Environment, ModelFactory, Task
 from strands_env.core.environment import EnvironmentConfig
@@ -43,7 +43,7 @@ from .reward import HarborReward
 if TYPE_CHECKING:
     from harbor.environments.base import BaseEnvironment
 
-    HarborEnvironment: TypeAlias = BaseEnvironment
+    type HarborEnvironment = BaseEnvironment
 
 
 class HarborConfig(EnvironmentConfig):

--- a/src/strands_env/environments/mcp_atlas/env.py
+++ b/src/strands_env/environments/mcp_atlas/env.py
@@ -18,10 +18,10 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Unpack, override
 
 import httpx
 from mcp.types import Tool as MCPToolDef
-from typing_extensions import Unpack, override
 
 from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.core.models import ModelFactory

--- a/src/strands_env/environments/mcp_atlas/reward.py
+++ b/src/strands_env/environments/mcp_atlas/reward.py
@@ -29,9 +29,9 @@ Scoring (from MCP-Atlas):
 from __future__ import annotations
 
 import logging
+from typing import override
 
 from pydantic import BaseModel, Field
-from typing_extensions import override
 
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 from strands_env.core.types import RewardResult, RolloutResult, Task

--- a/src/strands_env/environments/mcp_atlas/tool.py
+++ b/src/strands_env/environments/mcp_atlas/tool.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, override
 
 import httpx
 from mcp.types import Tool as MCPToolDef
 from strands.types.tools import ToolResultContent
-from typing_extensions import override
 
 from strands_env.core.mcp_tool import MCPToolAdapter
 

--- a/src/strands_env/environments/tau2_bench/simulator.py
+++ b/src/strands_env/environments/tau2_bench/simulator.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import logging
 import re
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from strands import Agent
@@ -47,7 +47,7 @@ from .tool import Tau2BenchTool
 logger = logging.getLogger(__name__)
 
 
-class Tau2BenchTerminationReason(str, Enum):
+class Tau2BenchTerminationReason(StrEnum):
     """Why the tau2 dialogue ended, in tau2's own vocabulary.
 
     Notes:

--- a/src/strands_env/environments/tau2_bench/tool.py
+++ b/src/strands_env/environments/tau2_bench/tool.py
@@ -17,11 +17,10 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, override
 
 from strands.tools.tools import AgentTool, ToolResultEvent
 from strands.types.tools import ToolGenerator, ToolResult, ToolResultContent, ToolSpec, ToolUse
-from typing_extensions import override
 
 from . import _tau2
 

--- a/src/strands_env/environments/web_search/env.py
+++ b/src/strands_env/environments/web_search/env.py
@@ -16,8 +16,7 @@
 
 import asyncio
 from pathlib import Path
-
-from typing_extensions import Unpack, override
+from typing import Unpack, override
 
 from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.core.models import ModelFactory

--- a/src/strands_env/environments/web_search/tools/search.py
+++ b/src/strands_env/environments/web_search/tools/search.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Literal, TypeAlias
+from typing import Literal
 
 import aiohttp
 from strands import tool
@@ -35,7 +35,7 @@ MAX_RESULTS = 10
 GOOGLE_SERPER_DEV_URL = "https://google.serper.dev/search"
 GOOGLE_CUSTOM_SEARCH_URL = "https://www.googleapis.com/customsearch/v1"
 
-WebSearchAPIProvider: TypeAlias = Literal["serper", "google"]
+type WebSearchAPIProvider = Literal["serper", "google"]
 
 
 class WebSearchToolkit:

--- a/src/strands_env/eval/benchmarks/aime.py
+++ b/src/strands_env/eval/benchmarks/aime.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
+from typing import override
 
 from datasets import load_dataset
-from typing_extensions import override
 
 from strands_env.core import Task
 

--- a/src/strands_env/eval/benchmarks/browsecomp.py
+++ b/src/strands_env/eval/benchmarks/browsecomp.py
@@ -20,11 +20,10 @@ import base64
 import hashlib
 import logging
 from collections.abc import Iterable
-from typing import Literal
+from typing import Literal, override
 
 import pandas as pd
 from pydantic import BaseModel, Field
-from typing_extensions import override
 
 from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward

--- a/src/strands_env/eval/benchmarks/frames.py
+++ b/src/strands_env/eval/benchmarks/frames.py
@@ -18,11 +18,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Any, Literal
+from typing import Any, Literal, override
 
 from datasets import load_dataset
 from pydantic import BaseModel, Field
-from typing_extensions import override
 
 from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward

--- a/src/strands_env/eval/benchmarks/gpqa.py
+++ b/src/strands_env/eval/benchmarks/gpqa.py
@@ -22,9 +22,9 @@ import re
 import sys
 import unicodedata
 from collections.abc import Iterable
+from typing import override
 
 from datasets import load_dataset
-from typing_extensions import override
 
 from strands_env.core import Task
 from strands_env.core.types import RewardFunction, RewardResult, RolloutResult

--- a/src/strands_env/eval/benchmarks/hle_verified.py
+++ b/src/strands_env/eval/benchmarks/hle_verified.py
@@ -22,12 +22,11 @@ import json
 import logging
 import re
 from collections.abc import Iterable
-from typing import Any, Literal
+from typing import Any, Literal, override
 
 from datasets import load_dataset
 from pydantic import BaseModel, Field
 from strands.types.content import Message
-from typing_extensions import override
 
 from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward

--- a/src/strands_env/eval/benchmarks/hmmt.py
+++ b/src/strands_env/eval/benchmarks/hmmt.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
+from typing import override
 
 from datasets import load_dataset
-from typing_extensions import override
 
 from strands_env.core import Task
 

--- a/src/strands_env/eval/benchmarks/ifeval.py
+++ b/src/strands_env/eval/benchmarks/ifeval.py
@@ -18,11 +18,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, override
 
 from datasets import load_dataset
 from lm_eval.tasks.ifeval.utils import process_results
-from typing_extensions import override
 
 from strands_env.core import Task
 from strands_env.core.types import RewardFunction, RewardResult, RolloutResult

--- a/src/strands_env/eval/benchmarks/mcp_atlas.py
+++ b/src/strands_env/eval/benchmarks/mcp_atlas.py
@@ -20,8 +20,7 @@ import ast
 import json
 import logging
 from collections.abc import Iterable
-
-from typing_extensions import override
+from typing import override
 
 from strands_env.core import AsyncEnvFactory, Task
 from strands_env.eval import EvalSample, Evaluator

--- a/src/strands_env/eval/benchmarks/sealqa.py
+++ b/src/strands_env/eval/benchmarks/sealqa.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, override
 
 from datasets import load_dataset
-from typing_extensions import override
 
 from strands_env.core import Task
 

--- a/src/strands_env/eval/benchmarks/simpleqa_verified.py
+++ b/src/strands_env/eval/benchmarks/simpleqa_verified.py
@@ -18,11 +18,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Literal
+from typing import Literal, override
 
 from datasets import load_dataset
 from pydantic import BaseModel, Field
-from typing_extensions import override
 
 from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward

--- a/src/strands_env/eval/benchmarks/swebench.py
+++ b/src/strands_env/eval/benchmarks/swebench.py
@@ -23,8 +23,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-
-from typing_extensions import override
+from typing import override
 
 from strands_env.core import Task
 from strands_env.environments.harbor import SWE_SYSTEM_PROMPT_PATH

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from typing import override
 
 from harbor.models.task.task import Task as HarborTask
-from typing_extensions import override
 
 from strands_env.core import Task
 from strands_env.environments.harbor import HarborConfig

--- a/src/strands_env/utils/aws.py
+++ b/src/strands_env/utils/aws.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TypeAlias
 
 import boto3
 from botocore.client import BaseClient
@@ -28,8 +27,8 @@ from strands_env.utils.decorators import cache_by
 
 logger = logging.getLogger(__name__)
 
-BotoClient: TypeAlias = BaseClient
-BotoClientConfig: TypeAlias = Config
+type BotoClient = BaseClient
+type BotoClientConfig = Config
 
 
 def resolve_region_name(region_name: str | None = None, profile_name: str | None = None) -> str:

--- a/src/strands_env/utils/loader.py
+++ b/src/strands_env/utils/loader.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import importlib
 from collections.abc import Callable
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from strands_env.core.environment import AsyncEnvFactory
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from strands_env.eval import Evaluator
 
 #: Type for the create_env_factory function exported by hook modules.
-EnvFactoryCreator: TypeAlias = Callable[..., AsyncEnvFactory]
+type EnvFactoryCreator = Callable[..., AsyncEnvFactory]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -16,6 +16,7 @@
 
 import threading
 import time
+from datetime import UTC
 from unittest.mock import MagicMock, patch
 
 import boto3
@@ -97,7 +98,7 @@ class TestGetSessionWithRoleAssumption:
     @patch("strands_env.utils.aws.boto3.client")
     @patch("botocore.session.get_session")
     def test_assumes_role(self, mock_get_session, mock_boto3_client):
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         mock_sts = MagicMock()
         mock_sts.assume_role.return_value = {
@@ -105,7 +106,7 @@ class TestGetSessionWithRoleAssumption:
                 "AccessKeyId": "AKIA_TEST",
                 "SecretAccessKey": "secret_test",
                 "SessionToken": "token_test",
-                "Expiration": datetime.now(timezone.utc),
+                "Expiration": datetime.now(UTC),
             }
         }
         mock_boto3_client.return_value = mock_sts
@@ -122,7 +123,7 @@ class TestGetSessionWithRoleAssumption:
 
     @patch("strands_env.utils.aws.boto3.client")
     def test_has_refreshable_credentials(self, mock_boto3_client):
-        from datetime import datetime, timedelta, timezone
+        from datetime import datetime, timedelta
 
         from botocore.credentials import RefreshableCredentials
 
@@ -132,7 +133,7 @@ class TestGetSessionWithRoleAssumption:
                 "AccessKeyId": "AKIA_TEST",
                 "SecretAccessKey": "secret_test",
                 "SessionToken": "token_test",
-                "Expiration": datetime.now(timezone.utc) + timedelta(hours=1),
+                "Expiration": datetime.now(UTC) + timedelta(hours=1),
             }
         }
         mock_boto3_client.return_value = mock_sts


### PR DESCRIPTION
## Summary

Slice 4: raise the Python floor to 3.12.

- 3.10/3.11 support had no remaining consumers and was costing real features: `harbor` and `agent-world-model` needed `python_version` markers (now unconditional deps), and the py312 lint target unlocks PEP 695 `type` alias statements plus `StrEnum` for the termination enums (`str()` now yields the value, not the qualified member name).
- CI matrix: `["3.12", "3.13"]`.
- `Generic[TaskT]` stays subscript-style (noqa UP046): the PEP 695 bracket syntax cannot express `TaskT`'s default until 3.13 is the floor — converting would silently degrade unparameterized `Environment` from `Environment[Task]` to `Environment[Any]`.

## Test plan

- 206 unit tests passed on 3.12; ruff (py312 target) and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)