### PR TITLE
fix(eval): don't abort-loop on missing rewards; warn at aggregation

### DIFF
--- a/src/strands_env/eval/benchmarks/browsecomp.py
+++ b/src/strands_env/eval/benchmarks/browsecomp.py
@@ -104,10 +104,10 @@ class BrowseCompEvaluator(Evaluator):
     @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward = sample.result.reward_result
-        if reward is None:
+        reward_result = sample.result.reward_result
+        if reward_result is None:
             return True
-        return reward.info.get("status") != "error"
+        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/frames.py
+++ b/src/strands_env/eval/benchmarks/frames.py
@@ -100,10 +100,10 @@ class FramesEvaluator(Evaluator):
     @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward = sample.result.reward_result
-        if reward is None:
+        reward_result = sample.result.reward_result
+        if reward_result is None:
             return True
-        return reward.info.get("status") != "error"
+        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/hle_verified.py
+++ b/src/strands_env/eval/benchmarks/hle_verified.py
@@ -124,10 +124,10 @@ class HLEVerifiedEvaluator(Evaluator):
     @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward = sample.result.reward_result
-        if reward is None:
+        reward_result = sample.result.reward_result
+        if reward_result is None:
             return True
-        return reward.info.get("status") != "error"
+        return reward_result.info.get("status") != "error"
 
     @staticmethod
     def parse_image_data_url(data_url: str) -> tuple[Literal["png", "jpeg", "gif", "webp"], bytes]:

--- a/src/strands_env/eval/benchmarks/mcp_atlas.py
+++ b/src/strands_env/eval/benchmarks/mcp_atlas.py
@@ -100,10 +100,11 @@ class MCPAtlasEvaluator(Evaluator):
     @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples where reward is missing or judge failed, so they are retried on resume."""
-        reward = sample.result.reward_result
-        if reward is None:
-            return False
-        return reward.info.get("status") != "error"
+        reward_result = sample.result.reward_result
+        if reward_result is None:
+            # no reward_fn configured — deterministic, retrying can't help (run() warns about it)
+            return True
+        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/sealqa.py
+++ b/src/strands_env/eval/benchmarks/sealqa.py
@@ -59,10 +59,10 @@ class SealQAEvaluator(Evaluator):
     @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward = sample.result.reward_result
-        if reward is None:
+        reward_result = sample.result.reward_result
+        if reward_result is None:
             return True
-        return reward.info.get("status") != "error"
+        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/simpleqa_verified.py
+++ b/src/strands_env/eval/benchmarks/simpleqa_verified.py
@@ -152,10 +152,10 @@ class SimpleQAVerifiedEvaluator(Evaluator):
     @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward = sample.result.reward_result
-        if reward is None:
+        reward_result = sample.result.reward_result
+        if reward_result is None:
             return True
-        return reward.info.get("status") != "error"
+        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -73,10 +73,10 @@ class Tau2BenchEvaluator(Evaluator):
     @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples with missing reward, NL judge error, or an aborted user-sim (all retryable)."""
-        reward = sample.result.reward_result
-        if reward is None:
+        reward_result = sample.result.reward_result
+        if reward_result is None:
             return False
-        nl_judge = reward.info.get("nl_judge")
+        nl_judge = reward_result.info.get("nl_judge")
         if nl_judge and nl_judge.get("status") == "error":
             return False
         if ((sample.result.metrics or {}).get("user_simulator") or {}).get("termination") == "aborted":

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -92,10 +92,11 @@ class TerminalBenchEvaluator(Evaluator):
     @override
     def validate_sample(self, sample: EvalSample) -> bool:
         """Abort samples where reward is missing or verification failed, so they are retried on resume."""
-        reward = sample.result.reward_result
-        if reward is None:
-            return False
-        return reward.info.get("status") != "error"
+        reward_result = sample.result.reward_result
+        if reward_result is None:
+            # no reward_fn configured — deterministic, retrying can't help (run() warns about it)
+            return True
+        return reward_result.info.get("status") != "error"
 
     @override
     async def evaluate_sample(self, task: Task) -> EvalSample:

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -231,6 +231,15 @@ class Evaluator:
             with tqdm(total=total, desc=f"Evaluating {self.benchmark_name}", unit="sample", dynamic_ncols=True) as pbar:
                 await asyncio.gather(*[process(pid, sid, a, pbar) for pid, sid, a in to_process])
         self.save_results()
+
+        # A missing reward is deterministic (no reward_fn configured), so samples are kept, not
+        # retried — but metrics count them as incorrect, which must not go unnoticed.
+        rewardless = sum(
+            1 for ss in self.results.values() for s in ss if not s.aborted and s.result.reward_result is None
+        )
+        if rewardless:
+            n = sum(len(ss) for ss in self.results.values())
+            logger.warning("%d/%d samples have no reward_result — metrics treat them as incorrect", rewardless, n)
         return dict(self.results)
 
     def compute_metrics(self, results: dict[str, list[EvalSample]], log: bool = True) -> dict[str, float]:


### PR DESCRIPTION
## Summary

Slice 6: unify the reward_result=None policy in validate_sample.

Five judge benchmarks kept rewardless samples while mcp-atlas and terminal-bench aborted them. A missing reward is a deterministic state (no reward_fn configured) — aborting means resume retries the same configuration forever. Policy unified: keep the sample (abort/retry is for transient failures like judge throttling), and `Evaluator.run()` now warns loudly when rewardless samples exist, since metrics count them as incorrect and an all-zero scoreboard must not read as "the model failed everything".

tau2-bench keeps None → abort: its reward_fn is hardcoded, so a missing reward there can only be a pipeline fault, not configuration.

Also renames validate_sample locals `reward` → `reward_result` across benchmarks for consistency.

## Test plan

- 206 unit tests passed; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)