### PR TITLE
feat(eval): parameterize the eval layer; migrate mcp-atlas to typed tasks

### DIFF
--- a/examples/eval/mcp_atlas/env.py
+++ b/examples/eval/mcp_atlas/env.py
@@ -39,7 +39,7 @@ def create_env_factory(model_config: dict, **env_config):
     docker_url = env_config.get("docker_url", MCPAtlasEnv.DEFAULT_DOCKER_URL)
     http_client = MCPAtlasEnv.create_client(base_url=docker_url)
 
-    async def env_factory(task):
+    async def env_factory(_task):
         # Each env gets its own reward_fn to avoid concurrent tasks overwriting
         # _current_claim / _response on a shared instance.
         reward_fn = MCPAtlasReward(judge_model=judge_models, max_model_retries=max_judge_retries)
@@ -47,7 +47,6 @@ def create_env_factory(model_config: dict, **env_config):
             model_factory=model_factory,
             http_client=http_client,
             reward_fn=reward_fn,
-            enabled_tools=task.enabled_tools,
             **env_config,
         )
 

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -162,6 +162,7 @@ class Environment(Generic[TaskT]):
     async def _compute_reward(self, task: TaskT, result: RolloutResult) -> None:
         """Compute and time the reward (if any), recording `reward_latency_s` in the metrics."""
         if self.reward_fn is None:
+            # no reward function usually means inference-only mode
             return
         reward_t0 = time.perf_counter()
         result.reward_result = await self.reward_fn.compute(task, result)

--- a/src/strands_env/environments/mcp_atlas/env.py
+++ b/src/strands_env/environments/mcp_atlas/env.py
@@ -18,15 +18,16 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Unpack, override
+from typing import NotRequired, Unpack, override
 
 import httpx
 from mcp.types import Tool as MCPToolDef
 
 from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.core.models import ModelFactory
-from strands_env.core.types import RewardFunction, Task
+from strands_env.core.types import RewardFunction
 
+from .task import MCPAtlasTask
 from .tool import MCPAtlasTool
 
 logger = logging.getLogger(__name__)
@@ -35,11 +36,10 @@ logger = logging.getLogger(__name__)
 class MCPAtlasConfig(EnvironmentConfig):
     """Serializable configuration for `MCPAtlasEnv`."""
 
-    enabled_tools: list[str]
-    tool_timeout: int
+    tool_timeout: NotRequired[int]
 
 
-class MCPAtlasEnv(Environment):
+class MCPAtlasEnv(Environment[MCPAtlasTask]):
     """MCP-Atlas benchmark environment backed by a Docker container.
 
     Notes:
@@ -59,7 +59,7 @@ class MCPAtlasEnv(Environment):
         *,
         model_factory: ModelFactory,
         http_client: httpx.AsyncClient,
-        reward_fn: RewardFunction | None = None,
+        reward_fn: RewardFunction[MCPAtlasTask] | None = None,
         cached_tools: list[dict] | None = None,
         **config: Unpack[MCPAtlasConfig],
     ):
@@ -73,8 +73,6 @@ class MCPAtlasEnv(Environment):
         self._cached_tools = cached_tools
         self._tools: list[MCPAtlasTool] = []
         self._tool_timeout: int = int(self.config.get("tool_timeout", 60))
-        enabled = self.config.get("enabled_tools")
-        self._enabled_tools = set(enabled) if enabled else None
 
     @staticmethod
     def create_client(
@@ -100,16 +98,17 @@ class MCPAtlasEnv(Environment):
         return httpx.AsyncClient(base_url=base_url, limits=limits)
 
     @override
-    async def reset(self, task: Task) -> None:
-        """Fetch tools from the container (or use cache) and apply per-task filter."""
+    async def reset(self, task: MCPAtlasTask) -> None:
+        """Fetch tools from the container (or use cache) and apply the task's tool filter."""
         if self._cached_tools is None:
             response = await self._http_client.post("/list-tools", timeout=self._tool_timeout)
             response.raise_for_status()
             self._cached_tools = response.json()
+        enabled_tools = set(task.enabled_tools)
         self._tools = [
             MCPAtlasTool(MCPToolDef.model_validate(tool), self._http_client, timeout=self._tool_timeout)
             for tool in self._cached_tools
-            if self._enabled_tools is None or tool["name"] in self._enabled_tools
+            if tool["name"] in enabled_tools
         ]
         logger.info("MCP-Atlas: %d tools enabled", len(self._tools))
 

--- a/src/strands_env/environments/mcp_atlas/reward.py
+++ b/src/strands_env/environments/mcp_atlas/reward.py
@@ -34,7 +34,9 @@ from typing import override
 from pydantic import BaseModel, Field
 
 from strands_env.core.llm_judge_reward import LLMJudgeReward
-from strands_env.core.types import RewardResult, RolloutResult, Task
+from strands_env.core.types import RewardResult, RolloutResult
+
+from .task import MCPAtlasTask
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +95,7 @@ class ClaimJudgment(BaseModel):
     confidence_level: float = Field(ge=0.0, le=1.0)
 
 
-class MCPAtlasReward(LLMJudgeReward[ClaimJudgment]):
+class MCPAtlasReward(LLMJudgeReward[ClaimJudgment, MCPAtlasTask]):
     """Per-claim LLM-as-judge reward for MCP-Atlas benchmark.
 
     Overrides ``compute()`` to evaluate multiple claims per rollout via
@@ -104,7 +106,7 @@ class MCPAtlasReward(LLMJudgeReward[ClaimJudgment]):
     judgment_format = ClaimJudgment
 
     @override
-    async def get_judge_prompt(self, task: Task, result: RolloutResult) -> str:
+    async def get_judge_prompt(self, task: MCPAtlasTask, result: RolloutResult) -> str:
         """Format the prompt for the current claim being evaluated."""
         return CLAIM_EVALUATION_PROMPT.format(claim=self._current_claim, response=self._response)
 
@@ -116,9 +118,9 @@ class MCPAtlasReward(LLMJudgeReward[ClaimJudgment]):
         return COVERAGE_SCORES.get(judgment.coverage_outcome, 0.0)
 
     @override
-    async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
+    async def compute(self, task: MCPAtlasTask, result: RolloutResult) -> RewardResult:
         """Evaluate each GTFA claim individually and return binary pass/fail reward."""
-        claims: list[str] = task.gtfa_claims  # type: ignore[attr-defined]
+        claims: list[str] = task.gtfa_claims
 
         if not claims:
             return RewardResult(reward=self.default_reward, info={"reason": "no_claims"})

--- a/src/strands_env/environments/mcp_atlas/task.py
+++ b/src/strands_env/environments/mcp_atlas/task.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""MCP-Atlas benchmark environment — Docker container with 36 MCP servers."""
+"""The dataset-authored MCP-Atlas sample type."""
 
-from .env import MCPAtlasConfig, MCPAtlasEnv
-from .reward import MCPAtlasReward
-from .task import MCPAtlasTask
-from .tool import MCPAtlasTool
+from __future__ import annotations
 
-__all__ = ["MCPAtlasConfig", "MCPAtlasEnv", "MCPAtlasReward", "MCPAtlasTask", "MCPAtlasTool"]
+from pydantic import Field
+
+from strands_env.core import Task
+
+
+class MCPAtlasTask(Task):
+    """Rollout input for `MCPAtlasEnv`."""
+
+    enabled_tools: list[str] = Field(description="List of MCP tools available to the agent.")
+    gtfa_claims: list[str] = Field(description="List of ground truth final answer claims to evaluate.")

--- a/src/strands_env/eval/benchmarks/mcp_atlas.py
+++ b/src/strands_env/eval/benchmarks/mcp_atlas.py
@@ -22,7 +22,8 @@ import logging
 from collections.abc import Iterable
 from typing import override
 
-from strands_env.core import AsyncEnvFactory, Task
+from strands_env.core import AsyncEnvFactory
+from strands_env.environments.mcp_atlas import MCPAtlasTask
 from strands_env.eval import EvalSample, Evaluator
 
 from ..registry import register_eval
@@ -56,15 +57,8 @@ DEFAULT_SERVERS = frozenset(
 )
 
 
-class MCPAtlasTask(Task):
-    """`Task` with MCP-Atlas-specific fields."""
-
-    enabled_tools: list[str]
-    gtfa_claims: list[str]
-
-
 @register_eval("mcp-atlas")
-class MCPAtlasEvaluator(Evaluator):
+class MCPAtlasEvaluator(Evaluator[MCPAtlasTask]):
     """Evaluator for MCP-Atlas benchmark."""
 
     benchmark_name = "mcp-atlas"
@@ -88,7 +82,7 @@ class MCPAtlasEvaluator(Evaluator):
         self._available_servers = available_servers
 
     @override
-    async def run(self, tasks: Iterable[Task]) -> dict[str, list[EvalSample]]:
+    async def run(self, tasks: Iterable[MCPAtlasTask]) -> dict[str, list[EvalSample[MCPAtlasTask]]]:
         """Run evaluation, closing any shared HTTP client at the end."""
         try:
             return await super().run(tasks)
@@ -98,7 +92,7 @@ class MCPAtlasEvaluator(Evaluator):
                 await http_client.aclose()
 
     @override
-    def validate_sample(self, sample: EvalSample) -> bool:
+    def validate_sample(self, sample: EvalSample[MCPAtlasTask]) -> bool:
         """Abort samples where reward is missing or judge failed, so they are retried on resume."""
         reward_result = sample.result.reward_result
         if reward_result is None:
@@ -107,7 +101,7 @@ class MCPAtlasEvaluator(Evaluator):
         return reward_result.info.get("status") != "error"
 
     @override
-    def load_dataset(self) -> Iterable[Task]:
+    def load_dataset(self) -> Iterable[MCPAtlasTask]:
         """Load MCP-Atlas tasks from HuggingFace, filter by available servers."""
         from datasets import load_dataset
 

--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -23,7 +23,6 @@ from functools import partial
 from pathlib import Path
 from typing import Literal, override
 
-from strands_env.core import Task
 from strands_env.environments.tau2_bench import Tau2BenchTask, _tau2
 from strands_env.eval import Evaluator
 from strands_env.eval.evaluator import EvalSample
@@ -38,7 +37,7 @@ os.environ.setdefault("TAU2_DATA_DIR", str((DATA_DIR / "data").resolve()))
 logger = logging.getLogger(__name__)
 
 
-class Tau2BenchEvaluator(Evaluator):
+class Tau2BenchEvaluator(Evaluator[Tau2BenchTask]):
     """Base evaluator for tau2-bench; subclasses set `domain`."""
 
     benchmark_name: str = "tau2-bench"
@@ -56,7 +55,7 @@ class Tau2BenchEvaluator(Evaluator):
         )
 
     @override
-    def load_dataset(self) -> list[Task]:
+    def load_dataset(self) -> list[Tau2BenchTask]:
         """Enumerate tasks for `self.domain` and bundle statics into each Task."""
         if not self.data_dir.exists():
             self._download_dataset()
@@ -71,7 +70,7 @@ class Tau2BenchEvaluator(Evaluator):
         ]
 
     @override
-    def validate_sample(self, sample: EvalSample) -> bool:
+    def validate_sample(self, sample: EvalSample[Tau2BenchTask]) -> bool:
         """Abort samples with missing reward, NL judge error, or an aborted user-sim (all retryable)."""
         reward_result = sample.result.reward_result
         if reward_result is None:

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -24,13 +24,14 @@ from collections import defaultdict
 from collections.abc import Iterable
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic
 
 from pydantic import BaseModel
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
-from strands_env.core import AsyncEnvFactory, RolloutResult, Task
+from strands_env.core import AsyncEnvFactory, RolloutResult
+from strands_env.core.types import TaskT
 
 from .metrics import MetricFunction, compute_pass_at_k
 
@@ -40,10 +41,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class EvalSample(BaseModel):
+class EvalSample(BaseModel, Generic[TaskT]):
     """Evaluation sample result."""
 
-    task: Task
+    task: TaskT
     """The task that was evaluated."""
 
     result: RolloutResult
@@ -53,7 +54,7 @@ class EvalSample(BaseModel):
     """Whether this sample was aborted (excluded from metrics, retried on resume)."""
 
 
-class Evaluator:
+class Evaluator(Generic[TaskT]):
     """Evaluator for running concurrent environment evaluations."""
 
     benchmark_name: str = ""
@@ -95,18 +96,18 @@ class Evaluator:
         self.keep_rollout = keep_rollout
 
         # Runtime state
-        self.results: dict[str, list[EvalSample]] = defaultdict(list)
+        self.results: dict[str, list[EvalSample[TaskT]]] = defaultdict(list)
         self.completed_ids: set[str] = set()
 
         # Strands' `recurse_event_loop` adds ~3 frames per tool iteration; the default
         # 1000-frame limit busts at ~iter 321 deep inside the OTel tracer's `json.dumps`.
         sys.setrecursionlimit(max(sys.getrecursionlimit(), 10_000))
 
-    def load_dataset(self) -> Iterable[Task]:
+    def load_dataset(self) -> Iterable[TaskT]:
         """Load dataset. Override in subclasses."""
         raise NotImplementedError("Subclasses must implement load_dataset()")
 
-    def validate_sample(self, sample: EvalSample) -> bool:
+    def validate_sample(self, _sample: EvalSample[TaskT]) -> bool:
         """Check if a completed sample is valid. Override with benchmark-specific logic.
 
         Return False to mark the sample as aborted (excluded from metrics, retried on resume).
@@ -140,7 +141,7 @@ class Evaluator:
             for line in f:
                 data = json.loads(line)
                 prompt_id = data.pop("prompt_id")
-                sample = EvalSample.model_validate(data)
+                sample: EvalSample[TaskT] = EvalSample.model_validate(data)
                 if sample.aborted:
                     n_aborted += 1
                     continue  # Aborted samples are retried on resume
@@ -161,7 +162,7 @@ class Evaluator:
                     data["prompt_id"] = prompt_id
                     f.write(json.dumps(data, ensure_ascii=False) + "\n")
 
-    async def evaluate_sample(self, task: Task) -> EvalSample:
+    async def evaluate_sample(self, task: TaskT) -> EvalSample[TaskT]:
         """Evaluate a single sample."""
         try:
             # Run evaluation in distributed or local mode
@@ -196,12 +197,12 @@ class Evaluator:
             logger.error("[%s]: evaluate_sample failed, aborting: %s", task.id, e)
             return EvalSample(task=task, result=RolloutResult(), aborted=True)
 
-    async def run(self, tasks: Iterable[Task]) -> dict[str, list[EvalSample]]:
+    async def run(self, tasks: Iterable[TaskT]) -> dict[str, list[EvalSample[TaskT]]]:
         """Run evaluation on tasks with `n_samples_per_prompt` each."""
         self.load_results()
 
         # Expand tasks to (prompt_id, sample_id, task) tuples
-        to_process: list[tuple[str, str, Task]] = []
+        to_process: list[tuple[str, str, TaskT]] = []
         for task in tasks:
             prompt_id = task.id
             for i in range(self.n_samples_per_prompt):
@@ -215,7 +216,7 @@ class Evaluator:
         save_counter = 0
         total = len(to_process)
 
-        async def process(prompt_id: str, sample_id: str, task: Task, pbar: tqdm) -> None:
+        async def process(prompt_id: str, sample_id: str, task: TaskT, pbar: tqdm) -> None:
             nonlocal save_counter
             async with semaphore:
                 sample = await self.evaluate_sample(task)

--- a/src/strands_env/eval/registry.py
+++ b/src/strands_env/eval/registry.py
@@ -24,7 +24,7 @@ import importlib
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from .evaluator import Evaluator
@@ -32,13 +32,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Registry: benchmark name -> Evaluator subclass
-_BENCHMARKS: dict[str, type[Evaluator]] = {}
+_BENCHMARKS: dict[str, type[Evaluator[Any]]] = {}
 # Unavailable modules: module_name -> error message
 _UNAVAILABLE: dict[str, str] = {}
 _DISCOVERED = False
 
 
-def register_eval(name: str) -> Callable[[type[Evaluator]], type[Evaluator]]:
+#: Bound to the class object itself so `register_eval` preserves the decorated class's exact type.
+EvaluatorT = TypeVar("EvaluatorT", bound="type[Evaluator[Any]]")
+
+
+def register_eval(name: str) -> Callable[[EvaluatorT], EvaluatorT]:
     """Decorator to register a benchmark evaluator.
 
     Example:
@@ -47,7 +51,7 @@ def register_eval(name: str) -> Callable[[type[Evaluator]], type[Evaluator]]:
             ...
     """
 
-    def decorator(cls: type[Evaluator]) -> type[Evaluator]:
+    def decorator(cls: EvaluatorT) -> EvaluatorT:
         if name in _BENCHMARKS:
             raise ValueError(f"Benchmark '{name}' is already registered")
         _BENCHMARKS[name] = cls
@@ -81,7 +85,7 @@ def _discover_benchmarks() -> None:
     _DISCOVERED = True
 
 
-def get_benchmark(name: str) -> type[Evaluator]:
+def get_benchmark(name: str) -> type[Evaluator[Any]]:
     """Get a registered benchmark evaluator by name.
 
     Args:


### PR DESCRIPTION
## Summary

Slice 7 (final slice of the lifecycle v2 series):

**Eval generics** — `Evaluator(Generic[TaskT])` with `EvalSample(BaseModel, Generic[TaskT])`: a concrete benchmark's task type flows load_dataset → evaluate_sample → validate_sample end to end. Unparameterized benchmarks keep meaning `Evaluator[Task]` (PEP 696 default). The registry stays the honest erasure boundary (`type[Evaluator[Any]]` — a string-keyed runtime lookup can't be statically typed, and a bare `Evaluator` bound would silently mean `Evaluator[Task]` and reject every parameterized benchmark), while `register_eval` becomes identity-preserving via a TypeVar bound to the class object.

**mcp-atlas migration** — `MCPAtlasTask` moves into the environment package: `enabled_tools`/`gtfa_claims` are dataset-authored fields, `reset(task)` applies the task's tool filter directly (the per-sample `enabled_tools` config key and its factory shuttle are gone; the old "no config = expose every tool" hatch is removed — MCP-Atlas tasks always declare their tool set). `MCPAtlasConfig` shrinks to `tool_timeout`. Parameterized end to end: `Environment[MCPAtlasTask]`, `LLMJudgeReward[ClaimJudgment, MCPAtlasTask]` (killing the `type: ignore` on `task.gtfa_claims`), `Evaluator[MCPAtlasTask]`.

## Breaking (mcp-atlas only)

- `MCPAtlasEnv(..., enabled_tools=...)` → the filter arrives on the task: `MCPAtlasTask(enabled_tools=..., gtfa_claims=...)`.

## Test plan

- 206 unit tests passed; ruff/mypy clean.

Remaining lifecycle-v2 work lands as separate PRs: harbor + agent-world-model payload migrations, then the zero-arg `EnvFactory` flip with the actor-side `task_cls` upcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)