### PR TITLE
chore: require strands-sglang>=0.5.0 (Python 3.12 floor)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-sglang>=0.4.3",
+    "strands-sglang>=0.5.0",
     "strands-agents-tools>=0.2.0",
     "openai",
     "datasets",


### PR DESCRIPTION
One-line pin bump: strands-sglang v0.5.0 raises its Python floor to 3.12, matching this repo (#173). Unit tests pass against the released 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)