### PR TITLE
refactor: audit class-attribute conventions; document the rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,9 +129,29 @@ Each environment is a package: `env.py` holds the `Environment` subclass, plus d
 - Use single backticks `` `xx` `` in docstrings (not Sphinx-style double backticks)
 - `__init__` docstrings should be `"""Initialize a `ClassName` instance."""`
 - Conventional commits (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert)
-- Python 3.10+ required
+- Python 3.12+ required (CI tests 3.12 and 3.13)
 - asyncio_mode = "auto" for pytest-asyncio
 - Async-first: all Environment methods that interact with Agent are async
+
+### Class Attribute Conventions
+
+Three forms, chosen by where the value's storage lives and whether the name binds a single value:
+
+- **Bare class-body annotation** (`tau2_env: Tau2Environment`) — instance attribute born later
+  (usually in `reset(task)`), PEP 526's "instance variable without default". Non-Optional for mypy;
+  accessing before birth raises AttributeError loudly. Never `ClassVar`.
+- **`NAME: ClassVar[T] = value` (UPPER_SNAKE)** — true constant: one value program-wide, readers may
+  inline it mentally; `ClassVar` forbids instance shadowing (a fidelity hazard for benchmark
+  material like prompts and stop patterns). `DEFAULT_*` uppercase = the single canonical fallback
+  value. On pydantic models/dataclasses `ClassVar` is mandatory (else it becomes a field).
+- **`name: T = value` (lowercase)** — subclass-overridable knob (`benchmark_name`, `domain`,
+  `default_system_prompt_path`): the value is polymorphic across subclasses, so it is not a
+  constant to the reader. Declare (with annotation) once where the name is introduced — usually the
+  base class; subclasses override with bare assignments, no re-annotation (the declaration is
+  inherited and mypy checks assignments against it). Add `ClassVar` when per-instance variation has
+  its own channel (e.g. `system_prompt` config vs `default_system_prompt_path`).
+
+Enum members are the exception to everything above: bare UPPER assignments, never annotated.
 
 ## Releases
 

--- a/src/strands_env/environments/agentcore_code/quotas.py
+++ b/src/strands_env/environments/agentcore_code/quotas.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from typing import Any
+from typing import Any, ClassVar
 
 from aiolimiter import AsyncLimiter
 
@@ -41,10 +41,10 @@ class CodeInterpreterQuotas:
         - [AWS Bedrock AgentCore default quotas](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/bedrock-agentcore-limits.html)
     """
 
-    DEFAULT_SESSION_CONCURRENCY = 1000
-    DEFAULT_START_TPS = 30
-    DEFAULT_INVOKE_TPS = 30
-    DEFAULT_STOP_TPS = 30
+    DEFAULT_SESSION_CONCURRENCY: ClassVar[int] = 1000
+    DEFAULT_START_TPS: ClassVar[int] = 30
+    DEFAULT_INVOKE_TPS: ClassVar[int] = 30
+    DEFAULT_STOP_TPS: ClassVar[int] = 30
 
     def __init__(
         self,

--- a/src/strands_env/environments/agentcore_code/tool.py
+++ b/src/strands_env/environments/agentcore_code/tool.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from strands import tool
 
@@ -37,8 +37,8 @@ class CodeInterpreterToolkit:
           `cleanup` when done to close the session.
     """
 
-    CODE_INTERPRETER_ID = "aws.codeinterpreter.v1"
-    DEFAULT_SESSION_TIMEOUT_SECONDS = 3600
+    CODE_INTERPRETER_ID: ClassVar[str] = "aws.codeinterpreter.v1"
+    DEFAULT_SESSION_TIMEOUT_SECONDS: ClassVar[int] = 3600
 
     def __init__(
         self,

--- a/src/strands_env/environments/mcp_atlas/env.py
+++ b/src/strands_env/environments/mcp_atlas/env.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import NotRequired, Unpack, override
+from typing import ClassVar, NotRequired, Unpack, override
 
 import httpx
 from mcp.types import Tool as MCPToolDef
@@ -50,7 +50,7 @@ class MCPAtlasEnv(Environment[MCPAtlasTask]):
         - ``cleanup()`` clears the tool list only.
     """
 
-    DEFAULT_DOCKER_URL = "http://localhost:1984"
+    DEFAULT_DOCKER_URL: ClassVar[str] = "http://localhost:1984"
 
     default_system_prompt_path = Path(__file__).parent / "system_prompt.md"
 

--- a/src/strands_env/environments/tau2_bench/env.py
+++ b/src/strands_env/environments/tau2_bench/env.py
@@ -68,7 +68,10 @@ class Tau2BenchConfig(EnvironmentConfig):
 class Tau2BenchEnv(Environment[Tau2BenchTask]):
     """Tau2-bench environment with user-simulator driving the multi-turn dialogue."""
 
+    # instance variables without default values and to be set in `reset(task)`
     user_simulator: Tau2BenchUserSimulator
+    agent_tools: list[Tau2BenchTool]
+    user_tools: list[Tau2BenchTool]
 
     def __init__(
         self,
@@ -83,8 +86,6 @@ class Tau2BenchEnv(Environment[Tau2BenchTask]):
 
         self.max_steps: int = self.config.get("max_steps", 100)
         self.user_model_factory = user_model_factory
-        self.agent_tools: list = []
-        self.user_tools: list = []
 
         judge_model = judge_model_factory() if judge_model_factory else None
         self.reward_fn: Tau2BenchReward = Tau2BenchReward(env=self, judge_model=judge_model)
@@ -96,11 +97,14 @@ class Tau2BenchEnv(Environment[Tau2BenchTask]):
         tau2_env = task.tau2_env
         self.system_prompt = SYSTEM_PROMPT_TEMPLATE.format(domain_policy=tau2_env.policy)
         self.agent_tools = [Tau2BenchTool(t, tau2_env, "assistant") for t in tau2_env.tools.get_tools().values()]
-        if tau2_env.user_tools:
-            self.user_tools = [
+        self.user_tools = (
+            [
                 Tau2BenchTool(t, tau2_env, "user")
                 for t in tau2_env.user_tools.get_tools(include=tau2_task.user_tools).values()
             ]
+            if tau2_env.user_tools
+            else []
+        )
         self.user_simulator = Tau2BenchUserSimulator(
             model=self.user_model_factory(),
             scenario=str(tau2_task.user_scenario),

--- a/src/strands_env/environments/tau2_bench/simulator.py
+++ b/src/strands_env/environments/tau2_bench/simulator.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import logging
 import re
 from enum import StrEnum
-from typing import Any
+from typing import Any, ClassVar
 
 from strands import Agent
 from strands.agent.conversation_manager import NullConversationManager
@@ -68,9 +68,9 @@ class Tau2BenchUserSimulator(HookProvider):
     `invoke_async()`.
     """
 
-    GREETING_MESSAGE: str = "Hi! How can I help you today?"
-    SYSTEM_PROMPT_TEMPLATE: str = "{guidelines}\n\n<scenario>\n{scenario}\n</scenario>"
-    STOP_PATTERN: re.Pattern[str] = re.compile(r"###(STOP|TRANSFER|OUT-OF-SCOPE)###")
+    GREETING_MESSAGE: ClassVar[str] = "Hi! How can I help you today?"
+    SYSTEM_PROMPT_TEMPLATE: ClassVar[str] = "{guidelines}\n\n<scenario>\n{scenario}\n</scenario>"
+    STOP_PATTERN: ClassVar[re.Pattern[str]] = re.compile(r"###(STOP|TRANSFER|OUT-OF-SCOPE)###")
 
     def __init__(
         self,

--- a/src/strands_env/eval/benchmarks/frames.py
+++ b/src/strands_env/eval/benchmarks/frames.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Any, Literal, override
+from typing import Literal, override
 
 from datasets import load_dataset
 from pydantic import BaseModel, Field
@@ -59,13 +59,6 @@ class FramesJudgment(BaseModel):
         ...,
         description="TRUE if the ground truth answer is present in the predicted answer, FALSE otherwise.",
     )
-
-
-class FramesTask(Task):
-    """`Task` with FRAMES row metadata (kept for reporting/analysis)."""
-
-    wiki_links: Any = None
-    reasoning_types: Any = None
 
 
 class FramesReward(LLMJudgeReward[FramesJudgment]):
@@ -120,10 +113,10 @@ class FramesEvaluator(Evaluator):
                 logger.warning("Row %s: missing Prompt/Answer, skipped", i)
                 continue
 
-            yield FramesTask(
+            yield Task(
                 id=f"{self.benchmark_name}_{i}",
                 message=str(prompt),
                 ground_truth=str(answer),
-                wiki_links=row["wiki_links"],
-                reasoning_types=row["reasoning_types"],
+                # untyped metadata bag, kept in saved results for analysis
+                **{"wiki_links": row["wiki_links"], "reasoning_types": row["reasoning_types"]},
             )

--- a/src/strands_env/eval/benchmarks/gpqa.py
+++ b/src/strands_env/eval/benchmarks/gpqa.py
@@ -22,7 +22,7 @@ import re
 import sys
 import unicodedata
 from collections.abc import Iterable
-from typing import override
+from typing import ClassVar, override
 
 from datasets import load_dataset
 
@@ -56,13 +56,13 @@ class GPQAReward(RewardFunction):
 
     #: Primary regex — matches `(A)` through `(Z)` with parentheses (case-sensitive,
     #: matching lm-evaluation-harness where ``ignore_case`` only applies to choice text).
-    PRIMARY_PATTERN: re.Pattern[str] = re.compile(r"\(([A-Z])\)")
+    PRIMARY_PATTERN: ClassVar[re.Pattern[str]] = re.compile(r"\(([A-Z])\)")
 
     #: Fallback regex — bare letter after a colon, e.g. `Answer: B`.
-    COLON_PATTERN: re.Pattern[str] = re.compile(r":[\s]*([A-D])")
+    COLON_PATTERN: ClassVar[re.Pattern[str]] = re.compile(r":[\s]*([A-D])")
 
     #: Punctuation translation table matching lm-evaluation-harness.
-    PUNCT_TBL: dict[int, None] = dict.fromkeys(
+    PUNCT_TBL: ClassVar[dict[int, None]] = dict.fromkeys(
         i for i in range(sys.maxunicode) if unicodedata.category(chr(i)).startswith("P")
     )
 
@@ -131,7 +131,7 @@ class GPQAEvaluator(Evaluator):
     benchmark_name: str = "gpqa"
     dataset_path: str = "Idavidrein/gpqa"
 
-    CHOICE_LETTERS: tuple[str, ...] = ("A", "B", "C", "D")
+    CHOICE_LETTERS: ClassVar[tuple[str, ...]] = ("A", "B", "C", "D")
 
     @staticmethod
     def preprocess(text: str | None) -> str:

--- a/src/strands_env/eval/benchmarks/hle_verified.py
+++ b/src/strands_env/eval/benchmarks/hle_verified.py
@@ -22,7 +22,7 @@ import json
 import logging
 import re
 from collections.abc import Iterable
-from typing import Any, Literal, override
+from typing import Any, ClassVar, Literal, override
 
 from datasets import load_dataset
 from pydantic import BaseModel, Field
@@ -118,8 +118,10 @@ class HLEVerifiedEvaluator(Evaluator):
     dataset_path: str = "skylenage-ai/HLE-Verified"
     text_only: bool = False
 
-    _DATA_URL_RE = re.compile(r"^data:image/(?P<fmt>[^;]+);base64,(?P<payload>.*)$", re.IGNORECASE)
-    _SUPPORTED_IMAGE_FORMATS = frozenset({"png", "jpeg", "gif", "webp"})
+    _DATA_URL_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r"^data:image/(?P<fmt>[^;]+);base64,(?P<payload>.*)$", re.IGNORECASE
+    )
+    _SUPPORTED_IMAGE_FORMATS: ClassVar[frozenset[str]] = frozenset({"png", "jpeg", "gif", "webp"})
 
     @override
     def validate_sample(self, sample: EvalSample) -> bool:

--- a/src/strands_env/eval/benchmarks/sealqa.py
+++ b/src/strands_env/eval/benchmarks/sealqa.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Any, override
+from typing import override
 
 from datasets import load_dataset
 
@@ -36,17 +36,6 @@ SealQAReward = SimpleQAReward
 # ---------------------------------------------------------------------------
 # Evaluators — Seal-0 and Seal-Hard
 # ---------------------------------------------------------------------------
-
-
-class SealQATask(Task):
-    """`Task` with SealQA row metadata (kept for reporting/analysis)."""
-
-    freshness: Any = None
-    question_types: Any = None
-    effective_year: Any = None
-    search_results: Any = None
-    topic: Any = None
-    urls: Any = None
 
 
 class SealQAEvaluator(Evaluator):
@@ -79,16 +68,15 @@ class SealQAEvaluator(Evaluator):
                 logger.warning("Row %s: missing question/answer, skipped", i)
                 continue
 
-            yield SealQATask(
+            yield Task(
                 id=f"{self.benchmark_name}_{i}",
                 message=str(question),
                 ground_truth=str(answer),
-                freshness=row.get("freshness"),
-                question_types=row.get("question_types"),
-                effective_year=row.get("effective_year"),
-                search_results=row.get("search_results"),
-                topic=row.get("topic"),
-                urls=row.get("urls"),
+                # untyped metadata bag, kept in saved results for analysis
+                **{
+                    k: row.get(k)
+                    for k in ("freshness", "question_types", "effective_year", "search_results", "topic", "urls")
+                },
             )
 
 


### PR DESCRIPTION
## Summary

AST-swept every class-body attribute in `src/` (220 scanned) and unified them under one taxonomy, now documented in CLAUDE.md (§ Class Attribute Conventions):

| form | meaning |
|---|---|
| bare annotation (`tau2_env: Tau2Environment`) | instance attr born in `reset(task)` — non-Optional, loud AttributeError before birth |
| `NAME: ClassVar[T] = value` (UPPER) | true constant; instance shadowing (a fidelity hazard for benchmark material) is a type error |
| `name: T = value` (lowercase) | subclass knob — declared once where introduced, overridden with bare assignments |

Changes: 16 constants gain `ClassVar` (tau2 simulator, gpqa patterns, mcp-atlas/agentcore/hle); tau2's `agent_tools`/`user_tools` become bare declarations (the `[]` pre-assignment masked a conditional-assignment gap in `reset` — now assigned unconditionally); `FramesTask`/`SealQATask` deleted (all-`Any` fields, zero consumers — unconsumed metadata rides as an explicit dict-unpacked extras bag); CLAUDE.md gains the conventions section and drops the stale Python 3.10+ note.

Non-changes worth noting: enum members, subclass knob overrides, and `judgment_format` (base declaration already existed) were flagged by the sweep and confirmed correct as-is.

## Test plan

206 unit tests passed; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)