### PR TITLE
perf(tau2-bench): sparse-clone only data/ (2.9 GB → ~790 MB)

### DIFF
--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -49,8 +49,18 @@ class Tau2BenchEvaluator(Evaluator[Tau2BenchTask]):
         """Sparse-clone only `data/` at `git_ref` — the full repo is ~3 GB, mostly unrelated web assets."""
         self.data_dir.parent.mkdir(parents=True, exist_ok=True)
         subprocess.run(
-            ["git", "clone", "--depth", "1", "--branch", self.git_ref, "--filter=blob:none", "--sparse",
-             self.git_url, str(self.data_dir)],
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                self.git_ref,
+                "--filter=blob:none",
+                "--sparse",
+                self.git_url,
+                str(self.data_dir),
+            ],
             check=True,
         )
         subprocess.run(["git", "-C", str(self.data_dir), "sparse-checkout", "set", "data"], check=True)

--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -46,12 +46,14 @@ class Tau2BenchEvaluator(Evaluator[Tau2BenchTask]):
     data_dir: Path = DATA_DIR
 
     def _download_dataset(self) -> None:
-        """Clone tau2-bench data files at `git_ref` (not bundled with the `tau2` pip wheel)."""
+        """Sparse-clone only `data/` at `git_ref` — the full repo is ~3 GB, mostly unrelated web assets."""
         self.data_dir.parent.mkdir(parents=True, exist_ok=True)
         subprocess.run(
-            ["git", "clone", "--depth", "1", "--branch", self.git_ref, self.git_url, str(self.data_dir)],
+            ["git", "clone", "--depth", "1", "--branch", self.git_ref, "--filter=blob:none", "--sparse",
+             self.git_url, str(self.data_dir)],
             check=True,
         )
+        subprocess.run(["git", "-C", str(self.data_dir), "sparse-checkout", "set", "data"], check=True)
 
     @override
     def load_dataset(self) -> list[Tau2BenchTask]:


### PR DESCRIPTION
Flagged by the live smoke test in #179: the tau2 shallow clone hauled 1.9 GB of web/ assets the evaluator never reads. blob:none + sparse-checkout of `data/` keeps the layout (TAU2_DATA_DIR unchanged) and cuts the transfer ~3.7×. Verified live against v1.0.0 (787 MB, `data/tau2/domains` intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)