### PR TITLE
refactor(harbor): replace hand-rolled verification with harbor's Verifier

### DIFF
--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -29,6 +29,8 @@ from typing import TYPE_CHECKING, Literal, NotRequired, Unpack, override
 
 from harbor.environments.factory import EnvironmentFactory
 from harbor.models.environment_type import EnvironmentType
+from harbor.models.trial.config import ServiceVolumeConfig
+from harbor.models.trial.paths import EnvironmentPaths
 from strands import tool
 
 from strands_env.core import Environment, ModelFactory
@@ -98,6 +100,13 @@ class HarborEnv(Environment[HarborTask]):
                     session_id=session_id,
                     trial_paths=task.trial_paths,
                     task_env_config=task.task_env_config,
+                    mounts=[
+                        ServiceVolumeConfig(
+                            type="bind",
+                            source=task.trial_paths.verifier_dir.resolve().absolute().as_posix(),
+                            target=str(EnvironmentPaths.verifier_dir),
+                        )
+                    ],
                 )
             case "e2b":
                 # we use prebaked e2b for self-hosting on e.g., AWS

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from harbor.models.task.task import Task as HarborTaskSpec
+from harbor.models.trial.paths import EnvironmentPaths
 from harbor.verifier.verifier import Verifier
 
 from strands_env.core.types import RewardFunction, RewardResult, RolloutResult
@@ -45,6 +46,10 @@ class HarborReward(RewardFunction["HarborTask"]):
         try:
             assert self._env.sandbox is not None, "sandbox not initialized"
             timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout
+            # The verifier's output redirect needs its target dir; mounted backends (docker)
+            # materialize it via the bind mount, non-mounted ones (e2b) need it created.
+            await self._env.sandbox.exec(f"mkdir -p {EnvironmentPaths.verifier_dir}")
+
             verifier = Verifier(
                 task=HarborTaskSpec(Path(task.task_dir)),
                 trial_paths=task.trial_paths,

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -43,7 +43,7 @@ class HarborReward(RewardFunction["HarborTask"]):
     async def compute(self, task: HarborTask, result: RolloutResult) -> RewardResult:
         """Run harbor's Verifier in the sandbox and return its reward."""
         try:
-            assert self._env.sandbox is not None, "Sandbox not initialized"
+            assert self._env.sandbox is not None, "Sandbox was not initialized"
             timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout
             verifier = Verifier(
                 task=HarborTaskSpec(Path(task.task_dir)),
@@ -51,8 +51,7 @@ class HarborReward(RewardFunction["HarborTask"]):
                 environment=self._env.sandbox,
             )
             verifier_result = await asyncio.wait_for(verifier.verify(), timeout=timeout)
-            if "reward" not in verifier_result.rewards:
-                raise ValueError(f"verifier reported no 'reward' key (got keys: {sorted(verifier_result.rewards)})")
+            # reward.json is unvalidated upstream; loud indexing raises on a missing key, never a silent 0
             return RewardResult(reward=float(verifier_result.rewards["reward"]), info={"status": "success"})
         except Exception as e:
             logger.exception("Verification failed due to %s: %s", type(e).__name__, str(e))

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -41,29 +41,22 @@ class HarborReward(RewardFunction["HarborTask"]):
         self._env = env
 
     async def compute(self, task: HarborTask, result: RolloutResult) -> RewardResult:
-        """Run verification tests in Docker and return a binary reward."""
+        """Run harbor's Verifier in the sandbox and return its reward."""
         try:
-            reward = await self._run_verification(task)
-            return RewardResult(reward=reward, info={"status": "success"})
+            assert self._env.sandbox is not None, "Sandbox not initialized"
+            timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout
+            verifier = Verifier(
+                task=HarborTaskSpec(Path(task.task_dir)),
+                trial_paths=task.trial_paths,
+                environment=self._env.sandbox,
+            )
+            verifier_result = await asyncio.wait_for(verifier.verify(), timeout=timeout)
+
+            # Harbor's raw reward, as parsed from reward.json (first) or reward.txt. A missing
+            # "reward" key is malformed verifier output — fail loudly, never score 0 silently.
+            if "reward" not in verifier_result.rewards:
+                raise ValueError(f"verifier reported no 'reward' key (got keys: {sorted(verifier_result.rewards)})")
+            return RewardResult(reward=float(verifier_result.rewards["reward"]), info={"status": "success"})
         except Exception as e:
             logger.exception("Verification failed due to %s: %s", type(e).__name__, str(e))
             return RewardResult(reward=0.0, info={"status": "error", "message": str(e)})
-
-    async def _run_verification(self, task: HarborTask) -> float:
-        """Run harbor's own Verifier and return its reward."""
-        assert self._env.sandbox is not None, "Sandbox not initialized"
-        sandbox = self._env.sandbox
-        timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout
-
-        verifier = Verifier(
-            task=HarborTaskSpec(Path(task.task_dir)),
-            trial_paths=task.trial_paths,
-            environment=sandbox,
-        )
-        result = await asyncio.wait_for(verifier.verify(), timeout=timeout)
-
-        # Harbor's raw reward, as parsed from reward.json (first) or reward.txt. A missing
-        # "reward" key is malformed verifier output — fail loudly, never score 0 silently.
-        if "reward" not in result.rewards:
-            raise ValueError(f"verifier reported no 'reward' key (got keys: {sorted(result.rewards)})")
-        return float(result.rewards["reward"])

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -43,7 +43,7 @@ class HarborReward(RewardFunction["HarborTask"]):
     async def compute(self, task: HarborTask, result: RolloutResult) -> RewardResult:
         """Run harbor's Verifier in the sandbox and return its reward."""
         try:
-            assert self._env.sandbox is not None, "Sandbox was not initialized"
+            assert self._env.sandbox is not None, "sandbox not initialized"
             timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout
             verifier = Verifier(
                 task=HarborTaskSpec(Path(task.task_dir)),

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -51,9 +51,6 @@ class HarborReward(RewardFunction["HarborTask"]):
                 environment=self._env.sandbox,
             )
             verifier_result = await asyncio.wait_for(verifier.verify(), timeout=timeout)
-
-            # Harbor's raw reward, as parsed from reward.json (first) or reward.txt. A missing
-            # "reward" key is malformed verifier output — fail loudly, never score 0 silently.
             if "reward" not in verifier_result.rewards:
                 raise ValueError(f"verifier reported no 'reward' key (got keys: {sorted(verifier_result.rewards)})")
             return RewardResult(reward=float(verifier_result.rewards["reward"]), info={"status": "success"})

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -55,12 +55,6 @@ class HarborReward(RewardFunction["HarborTask"]):
         sandbox = self._env.sandbox
         timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout
 
-        # harbor exec is a non-login `bash -c` (no ~/.profile), so user-local tools — like the
-        # uv that swebench images install into ~/.local/bin — are not on PATH. Expose them
-        # additively; the graded swebench baseline (70.8%, #78) relied on an equivalent PATH
-        # prepend in the pre-Verifier flow.
-        await sandbox.exec('ln -sf "$HOME/.local/bin/"* /usr/local/bin/ 2>/dev/null || true')
-
         verifier = Verifier(
             task=HarborTaskSpec(Path(task.task_dir)),
             trial_paths=task.trial_paths,
@@ -68,6 +62,8 @@ class HarborReward(RewardFunction["HarborTask"]):
         )
         result = await asyncio.wait_for(verifier.verify(), timeout=timeout)
 
-        # Harbor's raw reward, as parsed from reward.json (first) or reward.txt. Current
-        # datasets emit binary 0/1 by construction; partial-credit tasks pass through intact.
-        return float(result.rewards.get("reward", 0.0))
+        # Harbor's raw reward, as parsed from reward.json (first) or reward.txt. A missing
+        # "reward" key is malformed verifier output — fail loudly, never score 0 silently.
+        if "reward" not in result.rewards:
+            raise ValueError(f"verifier reported no 'reward' key (got keys: {sorted(result.rewards)})")
+        return float(result.rewards["reward"])

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -46,10 +46,7 @@ class HarborReward(RewardFunction["HarborTask"]):
         try:
             assert self._env.sandbox is not None, "sandbox not initialized"
             timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout
-            # The verifier's output redirect needs its target dir; mounted backends (docker)
-            # materialize it via the bind mount, non-mounted ones (e2b) need it created.
             await self._env.sandbox.exec(f"mkdir -p {EnvironmentPaths.verifier_dir}")
-
             verifier = Verifier(
                 task=HarborTaskSpec(Path(task.task_dir)),
                 trial_paths=task.trial_paths,

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -16,10 +16,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from harbor.models.trial.paths import EnvironmentPaths
+from harbor.models.task.task import Task as HarborTaskSpec
+from harbor.verifier.verifier import Verifier
 
 from strands_env.core.types import RewardFunction, RewardResult, RolloutResult
 
@@ -31,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 class HarborReward(RewardFunction["HarborTask"]):
-    """Execute test scripts in Docker and compute binary reward (0 or 1)."""
+    """Run harbor's Verifier in the sandbox and return its reward."""
 
     def __init__(self, env: HarborEnv) -> None:
         """Initialize a `HarborReward` instance."""
@@ -47,30 +50,24 @@ class HarborReward(RewardFunction["HarborTask"]):
             return RewardResult(reward=0.0, info={"status": "error", "message": str(e)})
 
     async def _run_verification(self, task: HarborTask) -> float:
-        """Upload tests, execute `test.sh`, download results, and parse reward."""
+        """Run harbor's own Verifier and return its reward."""
         assert self._env.sandbox is not None, "Sandbox not initialized"
         sandbox = self._env.sandbox
-        task_paths = task.task_paths
-        trial_paths = task.trial_paths
         timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout
 
-        # Upload and run tests.
-        await sandbox.upload_dir(source_dir=task_paths.tests_dir, target_dir="/tests")
-        test_cmd = (
-            'export PATH="$HOME/.local/bin:$PATH" && '
-            f"bash /tests/test.sh 2>&1 | tee {EnvironmentPaths.verifier_dir}/test-stdout.txt"
+        # harbor exec is a non-login `bash -c` (no ~/.profile), so user-local tools — like the
+        # uv that swebench images install into ~/.local/bin — are not on PATH. Expose them
+        # additively; the graded swebench baseline (70.8%, #78) relied on an equivalent PATH
+        # prepend in the pre-Verifier flow.
+        await sandbox.exec('ln -sf "$HOME/.local/bin/"* /usr/local/bin/ 2>/dev/null || true')
+
+        verifier = Verifier(
+            task=HarborTaskSpec(Path(task.task_dir)),
+            trial_paths=task.trial_paths,
+            environment=sandbox,
         )
-        await sandbox.exec(test_cmd, timeout_sec=timeout)
+        result = await asyncio.wait_for(verifier.verify(), timeout=timeout)
 
-        # Download results if not using mounted volumes
-        if not sandbox.capabilities.mounted:
-            await sandbox.download_dir(
-                source_dir=str(EnvironmentPaths.verifier_dir),
-                target_dir=trial_paths.verifier_dir,
-            )
-
-        # Parse reward (1.0 if reward.txt contains value >= 1, else 0.0)
-        reward_path = trial_paths.reward_text_path
-        if reward_path.exists() and reward_path.stat().st_size > 0:
-            return 1.0 if float(reward_path.read_text().strip()) >= 1.0 else 0.0
-        raise RuntimeError(f"verification produced no reward file at {reward_path}")
+        # Harbor's raw reward, as parsed from reward.json (first) or reward.txt. Current
+        # datasets emit binary 0/1 by construction; partial-credit tasks pass through intact.
+        return float(result.rewards.get("reward", 0.0))

--- a/src/strands_env/eval/benchmarks/swebench.py
+++ b/src/strands_env/eval/benchmarks/swebench.py
@@ -41,7 +41,7 @@ class SWEBenchVerifiedEvaluator(TerminalBenchEvaluator):
     """
 
     git_url = "https://github.com/laude-institute/harbor-datasets.git"
-    git_ref = "0d48cdd78e14a1e22afa09abcfc1bf210427d66f"
+    git_ref = "37db108843a49bb31a592e37a75e2c40dc3f9749"  # test.sh self-exports ~/.local/bin (uv fix)
     git_subdir = "datasets/swebench-verified"
     system_prompt_path: Path | None = SWE_SYSTEM_PROMPT_PATH
 


### PR DESCRIPTION
## Summary

`HarborReward` delegates to `harbor.verifier.Verifier` (existed with today's signature since harbor 0.1.43, already pinned when the hand-rolled flow was first written — the divergence was accidental, not a workaround). Upstream now provides `reward.json` (partial credit) with `reward.txt` fallback, chmod/OS-aware execution, and typed verifier exceptions.

**Reward policy**: raw passthrough with loud indexing — a missing `"reward"` key raises into the error path (reward.json is unvalidated upstream); never a silent 0. The old binarization was empirically vacuous (all 89 local tb2/holdout tests and swebench's parser write literal 0/1).

**The uv/PATH saga, resolved upstream**: pinned harbor-datasets `0d48cdd` (2026-01-20) predates the upstream uv-PATH fix (`f0b9a568`, and later a self-contained `export PATH` inside `test.sh`) — under a non-login `bash -c` every swebench task would silently score 0. Resolution: **bump the swebench pin to HEAD (`37db1088`)** instead of carrying a compatibility shim; every other dataset was already self-sufficient (audited all 89: they `source $HOME/.local/bin/env` by absolute path).

**Two integration defects the live smoke caught** (static review could not): docker's `capabilities.mounted=True` makes the Verifier skip downloads, but we never wired the mount — results stranded in the container. Fixed by passing the same verifier bind mount harbor's own Trial wires. And the Verifier's output redirect requires `/logs/verifier` to exist — mount materializes it on docker; a pre-verify `mkdir -p` covers e2b.

**Live verification** (swebench `astropy__astropy-12907`, new pin, docker under x86 emulation): unpatched repo → uv runs via test.sh's own PATH export (no shim) → parser reports FAILED → `reward=0.0, status=success`, `report.json`/`test-stdout.txt` delivered to the host trial dir. The error path was also exercised en route (`RewardFileNotFoundError` → `status=error`, no silent zero).

**Breaking**: swebench dataset content changes with the pin (upstream patched instructions and regenerated tasks in March) — the 70.8% baseline from #78 is retired; re-baseline before comparing numbers.

## Test plan

238 unit tests, mypy strict, ruff + format, plus the live end-to-end verification above. plus a live e2b run on the self-hosted cluster (cancel-async-tasks, prebaked template): download branch delivered ctrf.json/reward.txt/test-stdout.txt to the host, reward=0.0 status=success on the unsolved task — the pre-verify mkdir fallback and the non-mounted download path are both exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
