### PR TITLE
docs: unify environment Configuration sections across READMEs

### DIFF
--- a/src/strands_env/environments/agent_world_model/README.md
+++ b/src/strands_env/environments/agent_world_model/README.md
@@ -24,30 +24,29 @@ env = AgentWorldModelEnv(
     temp_dir="/path/to/temp_dir",
     max_tool_iters=10,
 )
-await env.reset()       # starts server + opens MCP session
-result = await env.rollout(task)
-await env.cleanup()     # closes session + kills server + removes temp dir
+result = await env.rollout(task)  # reset (start server + open MCP session) -> episode -> reward -> cleanup
 ```
 
 `AgentWorldModelReward` is used by default — no need to pass `reward_fn` unless you want a custom one.
 
-## AgentWorldModelConfig
+## Configuration
 
-`AgentWorldModelConfig` extends `EnvironmentConfig` with AWM-specific fields. All config
-fields are serializable (strings, ints) and passed as `**kwargs` to the constructor.
+`AgentWorldModelConfig` keys (passed as `**kwargs`):
 
-| Field | Type | Description |
+| Field | Default | Meaning |
 |---|---|---|
-| `scenario` | `str` | Scenario name |
-| `envs_path` | `str` | Path to gen_envs.jsonl (contains `scenario`, `db_path`, `full_code`) |
-| `work_db_path` | `str` | Working DB copy the server writes to |
-| `initial_db_path` | `str` | Read-only DB snapshot (for reward verification) |
-| `temp_dir` | `str` | Temp directory for server artifacts (removed on cleanup) |
-| `tool_call_timeout` | `int` | MCP tool call timeout in seconds (default: 60) |
+| `scenario` | required | Scenario name |
+| `envs_path` | required | Path to `gen_envs.jsonl` (contains `scenario`, `db_path`, `full_code`) |
+| `work_db_path` | required | Working DB copy the server writes to |
+| `initial_db_path` | required | Read-only DB snapshot (for reward verification) |
+| `temp_dir` | required | Temp directory for server artifacts (removed on cleanup) |
+| `tool_call_timeout` | `60` | MCP tool call timeout in seconds |
 
-## TaskContext Fields
+Base knobs (`system_prompt`, `max_tool_iters`, `max_tool_calls`, `max_parallel_tool_calls`, `max_messages`, `trace_attributes`, `agent_name`, `verbose`) come from `EnvironmentConfig`.
 
-The evaluator/trainer must prepare these fields on `TaskContext` before creating the environment:
+## Task Fields
+
+The evaluator/trainer must prepare these fields on the `Task` (as extras) before `rollout()`:
 
 | Field | Type | Set by | Used by |
 |---|---|---|---|

--- a/src/strands_env/environments/agentcore_code/README.md
+++ b/src/strands_env/environments/agentcore_code/README.md
@@ -29,6 +29,17 @@ result = await env.rollout(task)
 await env.cleanup()  # Clean up code interpreter session
 ```
 
+## Configuration
+
+`AgentCoreCodeConfig` keys (passed as `**kwargs`):
+
+| Field | Default | Meaning |
+|---|---|---|
+| `mode` | `"code"` | Tools to expose: `"code"`, `"terminal"`, or `"code_and_terminal"` |
+| `session_timeout_seconds` | `3600` | Code interpreter session timeout in seconds |
+
+Base knobs (`system_prompt`, `max_tool_iters`, `max_tool_calls`, `max_parallel_tool_calls`, `max_messages`, `trace_attributes`, `agent_name`, `verbose`) come from `EnvironmentConfig`.
+
 ## Tools
 
 Depends on the configured mode:

--- a/src/strands_env/environments/calculator/README.md
+++ b/src/strands_env/environments/calculator/README.md
@@ -15,6 +15,10 @@ env = CalculatorEnv(model_factory=model_factory)
 result = await env.rollout(task)
 ```
 
+## Configuration
+
+No environment-specific keys — base knobs (`system_prompt`, `max_tool_iters`, `max_tool_calls`, `max_parallel_tool_calls`, `max_messages`, `trace_attributes`, `agent_name`, `verbose`) come from `EnvironmentConfig`.
+
 ## Tools
 
 - **calculator** — Basic arithmetic operations (from `strands_tools`).

--- a/src/strands_env/environments/harbor/README.md
+++ b/src/strands_env/environments/harbor/README.md
@@ -45,11 +45,21 @@ task = HarborTask.from_task_dir("/path/to/task", trial_dir="/path/to/output")  #
 result = await env.rollout(task)  # reset (build + start container) -> episode -> reward -> cleanup
 ```
 
-`HarborTask` carries the dataset-authored sample: `task_id`, `task_dir`, `trial_dir`,
+## Configuration
+
+`HarborConfig` keys (passed as `**kwargs`):
+
+| Field | Default | Meaning |
+|---|---|---|
+| `backend` | `"docker"` | Sandbox backend: `"docker"` or `"e2b"` |
+| `exec_timeout` | `1200` | Per-command `sandbox.exec` timeout in seconds; also the verifier fallback |
+| `prebaked_e2b_config` | `{}` | e2b connection + template config (`domain`, `api_key`/`api_key_file`, `template_id`, `templates_json`); connection falls back to `E2B_DOMAIN`/`E2B_API_KEY` |
+
+Base knobs (`system_prompt`, `max_tool_iters`, `max_tool_calls`, `max_parallel_tool_calls`, `max_messages`, `trace_attributes`, `agent_name`, `verbose`) come from `EnvironmentConfig`.
+
+The per-sample payload rides `HarborTask`, not config: `task_id`, `task_dir`, `trial_dir`,
 `task_env_config`, an optional `verifier_timeout` (task.toml `[verifier]`), and an optional
-benchmark `system_prompt`. `HarborConfig` keeps the operator knobs: `backend`,
-`exec_timeout` (per-command `sandbox.exec` budget, also the verifier fallback), and
-`prebaked_e2b_config`.
+benchmark `system_prompt` override.
 
 ## Tools
 
@@ -71,4 +81,4 @@ The env ships two prompts:
 - `system_prompt.md` (default) — drives a structured problem-solving loop: analyze state, plan next steps, execute commands, verify results.
 - `system_prompt_swe.md` — a SWE-bench-tuned variant (exposed as `SWE_SYSTEM_PROMPT_PATH`).
 
-Benchmarks override the default via the serializable `system_prompt` config field — e.g. the `swebench-verified` evaluator injects `system_prompt_swe.md`.
+Benchmarks override the default per-task via `HarborTask.system_prompt` — e.g. the `swebench-verified` evaluator injects `system_prompt_swe.md`.

--- a/src/strands_env/environments/harbor/__init__.py
+++ b/src/strands_env/environments/harbor/__init__.py
@@ -20,8 +20,8 @@ from .env import HarborConfig, HarborEnv
 from .reward import HarborReward
 from .task import HarborTask
 
-#: SWE-bench-tuned system prompt shipped with the env; benchmarks inject it via the
-#: serializable `system_prompt` config key (e.g. the `swebench-verified` evaluator).
+#: SWE-bench-tuned system prompt shipped with the env; benchmarks inject it per-task via
+#: `HarborTask.system_prompt` (e.g. the `swebench-verified` evaluator).
 SWE_SYSTEM_PROMPT_PATH = Path(__file__).parent / "system_prompt_swe.md"
 
 __all__ = ["SWE_SYSTEM_PROMPT_PATH", "HarborConfig", "HarborEnv", "HarborReward", "HarborTask"]

--- a/src/strands_env/environments/mcp_atlas/README.md
+++ b/src/strands_env/environments/mcp_atlas/README.md
@@ -35,26 +35,24 @@ env = MCPAtlasEnv(
     model_factory=model_factory,
     http_client=http_client,
     reward_fn=reward_fn,
-    enabled_tools=["calculator_calculate", "fetch_fetch"],
 )
-await env.reset()       # fetches tools and applies filtering
-result = await env.rollout(task)
-await env.cleanup()     # clears tools (does NOT close the shared client)
+result = await env.rollout(task)  # reset (fetch + filter tools) -> episode -> reward -> cleanup
+await http_client.aclose()  # caller owns the shared client — close after all tasks
 ```
 
-## MCPAtlasConfig
+## Configuration
 
-`MCPAtlasConfig` extends `EnvironmentConfig` with MCP-Atlas-specific fields.
-All config fields are serializable and passed as `**kwargs` to the constructor.
+`MCPAtlasConfig` keys (passed as `**kwargs`):
 
-| Field | Type | Description |
+| Field | Default | Meaning |
 |---|---|---|
-| `enabled_tools` | `list[str]` | Tool names to enable (omit or empty = all tools) |
-| `tool_timeout` | `int` | HTTP timeout in seconds for tool and list-tools calls (default: 60) |
+| `tool_timeout` | `60` | HTTP timeout in seconds for `/list-tools` and `/call-tool` requests |
 
-## TaskContext Fields
+Base knobs (`system_prompt`, `max_tool_iters`, `max_tool_calls`, `max_parallel_tool_calls`, `max_messages`, `trace_attributes`, `agent_name`, `verbose`) come from `EnvironmentConfig`.
 
-The evaluator must prepare these fields on `TaskContext` (via `MCPAtlasTaskContext`):
+## Task Fields
+
+The dataset-authored sample arrives as `MCPAtlasTask`:
 
 | Field | Type | Used by |
 |---|---|---|

--- a/src/strands_env/environments/tau2_bench/README.md
+++ b/src/strands_env/environments/tau2_bench/README.md
@@ -58,9 +58,13 @@ The reward is benchmark material and is not injectable; episodes not ended by th
 
 ## Configuration
 
-Operator-authored config via `Tau2BenchConfig` (passed as `**kwargs`):
+`Tau2BenchConfig` keys (passed as `**kwargs`):
 
-- `max_steps` — step budget in tau2's sense, shared by agent and user-sim (default 100)
+| Field | Default | Meaning |
+|---|---|---|
+| `max_steps` | `100` | Step budget in tau2's sense: total message count across agent and user-sim |
+
+Base knobs (`system_prompt`, `max_tool_iters`, `max_tool_calls`, `max_parallel_tool_calls`, `max_messages`, `trace_attributes`, `agent_name`, `verbose`) come from `EnvironmentConfig`.
 
 Dataset-authored sample via `Tau2BenchTask` (passed to `rollout()`):
 

--- a/src/strands_env/environments/web_search/README.md
+++ b/src/strands_env/environments/web_search/README.md
@@ -50,14 +50,18 @@ Depends on configuration:
 
 ## Configuration
 
-Serializable config via `WebSearchConfig` (passed as `**kwargs`):
+`WebSearchConfig` keys (passed as `**kwargs`):
 
-- `search_provider` — `"serper"` (default) or `"google"`
-- `search_timeout` — HTTP timeout in seconds (default 10)
-- `blocked_domains` — domains to exclude from results
-- `scrape_enabled` — enable web scraping (default `False`)
-- `scrape_timeout` — scrape HTTP timeout (default 30)
-- `scrape_token_budget` — max tokens of page content to keep (default 5000)
+| Field | Default | Meaning |
+|---|---|---|
+| `search_provider` | `"serper"` | Search API provider: `"serper"` or `"google"` |
+| `search_timeout` | `10` | Search HTTP timeout in seconds |
+| `blocked_domains` | `None` | Domains to exclude from search results |
+| `scrape_enabled` | `False` | Enable the scrape tool |
+| `scrape_timeout` | `50` | Scrape HTTP timeout in seconds |
+| `scrape_token_budget` | `20000` | Max tokens of scraped page content to keep |
+
+Base knobs (`system_prompt`, `max_tool_iters`, `max_tool_calls`, `max_parallel_tool_calls`, `max_messages`, `trace_attributes`, `agent_name`, `verbose`) come from `EnvironmentConfig`.
 
 Non-serializable params (named args):
 


### PR DESCRIPTION
## Summary

Every environment README (`agent_world_model`, `agentcore_code`, `calculator`, `harbor`, `mcp_atlas`, `tau2_bench`, `web_search`) now has a consistent, concise **Configuration** section: one `Field | Default | Meaning` table covering only that env's own config keys, plus one line noting the base knobs (`system_prompt`, `max_tool_iters`, `max_tool_calls`, `max_parallel_tool_calls`, `max_messages`, `trace_attributes`, `agent_name`, `verbose`) come from `EnvironmentConfig`.

All defaults verified against each `env.py`.

## Stale facts fixed along the way

- **web_search**: `scrape_timeout` default is `50` (README said 30), `scrape_token_budget` is `20000` (README said 5000)
- **mcp_atlas**: `enabled_tools` rides `MCPAtlasTask`, not `MCPAtlasConfig` — removed from the config table and the constructor example
- **harbor**: benchmark system prompt injection is per-task via `HarborTask.system_prompt`, not the `system_prompt` config key (README + `__init__.py` comment); per-sample payload (`task_id`/`task_dir`/`trial_dir`/`task_env_config`/`verifier_timeout`/`system_prompt`) documented as riding `HarborTask`, not config
- **agent_world_model / mcp_atlas**: stale `TaskContext` naming and invalid no-arg `env.reset()` / `env.cleanup()` usage replaced with `rollout(task)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)