### PR TITLE
refactor(agent-world-model)!: task owns its payload; env derives its scratch

### DIFF
--- a/src/strands_env/environments/agent_world_model/README.md
+++ b/src/strands_env/environments/agent_world_model/README.md
@@ -13,63 +13,57 @@ This installs [AgentWorldModel](https://pypi.org/project/agent-world-model/) (`a
 ## Usage
 
 ```python
-from strands_env.environments.agent_world_model import AgentWorldModelEnv
+from strands_env.environments.agent_world_model import AgentWorldModelEnv, AgentWorldModelTask
 
 env = AgentWorldModelEnv(
     model_factory=model_factory,
-    scenario="your_scenario",
     envs_path="/path/to/gen_envs.jsonl",
-    work_db_path="/path/to/work.db",
-    initial_db_path="/path/to/initial.db",
-    temp_dir="/path/to/temp_dir",
     max_tool_iters=10,
 )
-await env.reset()       # starts server + opens MCP session
-result = await env.rollout(task)
-await env.cleanup()     # closes session + kills server + removes temp dir
+
+task = AgentWorldModelTask(
+    message="Add two apples to the cart and report the total.",
+    scenario="your_scenario",
+    task_idx=0,
+    verify_code=verify_code,          # from gen_verifier.pure_code.jsonl
+    initial_db_path="/path/to/initial.db",
+)
+result = await env.rollout(task)  # reset (clone DB + start server) -> episode -> reward -> cleanup
 ```
 
-`AgentWorldModelReward` is used by default — no need to pass `reward_fn` unless you want a custom one.
+`AgentWorldModelReward` is built in — it is tied to the env's working DB, so there is no `reward_fn` parameter.
 
-## AgentWorldModelConfig
+## Configuration
 
-`AgentWorldModelConfig` extends `EnvironmentConfig` with AWM-specific fields. All config
-fields are serializable (strings, ints) and passed as `**kwargs` to the constructor.
-
-| Field | Type | Description |
+| Field | Default | Meaning |
 |---|---|---|
-| `scenario` | `str` | Scenario name |
-| `envs_path` | `str` | Path to gen_envs.jsonl (contains `scenario`, `db_path`, `full_code`) |
-| `work_db_path` | `str` | Working DB copy the server writes to |
-| `initial_db_path` | `str` | Read-only DB snapshot (for reward verification) |
-| `temp_dir` | `str` | Temp directory for server artifacts (removed on cleanup) |
-| `tool_call_timeout` | `int` | MCP tool call timeout in seconds (default: 60) |
+| `envs_path` | required | Path to `gen_envs.jsonl` (contains `scenario`, `db_path`, `full_code`) |
+| `tool_call_timeout` | `60` | MCP tool call timeout in seconds |
 
-## TaskContext Fields
+Base knobs (`system_prompt`, `max_tool_iters`, ...) come from `EnvironmentConfig`.
 
-The evaluator/trainer must prepare these fields on `TaskContext` before creating the environment:
+## Task Fields
 
-| Field | Type | Set by | Used by |
-|---|---|---|---|
-| `scenario` | `str` | evaluator | env, reward |
-| `envs_path` | `str` | evaluator | env |
-| `work_db_path` | `str` | evaluator | env, reward |
-| `initial_db_path` | `str` | evaluator | reward |
-| `temp_dir` | `str` | evaluator | env |
-| `verify_code` | `str` | evaluator | reward |
-| `task_idx` | `int` | evaluator | reward (logging) |
+`AgentWorldModelTask` carries the per-sample payload:
+
+| Field | Meaning |
+|---|---|
+| `scenario` | Scenario name in `gen_envs.jsonl` (which synthetic world to boot) |
+| `task_idx` | Task index within the scenario (used in logs) |
+| `verify_code` | Python source defining `verify_task_completion(...)` |
+| `initial_db_path` | Pristine SQLite snapshot; the episode's working DB is cloned from it |
 
 ## Reward
 
-`AgentWorldModelReward` runs the per-task `verify_task_completion(initial_db_path, final_db_path, final_answer)` function via `exec()`. Each scenario has a unique verification function (from `gen_verifier.pure_code.jsonl`) that checks:
+`AgentWorldModelReward` runs the task's `verify_task_completion(initial_db_path, final_db_path, final_answer)` via `exec()`. Each scenario has a unique verification function (from `gen_verifier.pure_code.jsonl`) that checks:
 
-- **DB state changes** — compares initial vs final SQLite database (e.g. "was the item added to cart?")
-- **Agent's final answer** — extracts the last assistant message via `RolloutResult.final_response` and validates it (e.g. "is the reported total correct?")
+- **DB state changes** — compares the initial snapshot against the episode's working DB (e.g. "was the item added to cart?")
+- **Agent's final answer** — validates `RolloutResult.final_response` (e.g. "is the reported total correct?")
 
-Returns 1.0 if `result["result"] == "complete"`, 0.0 otherwise.
+Returns 1.0 if `result["result"] == "complete"`, 0.0 otherwise. `info["status"]` is `"success"` whenever the verifier ran (reward 0.0 = the agent failed the task) and `"error"` only for verification-machinery failures — the same contract as the other environments.
 
 ## Lifecycle
 
-- **`reset()`** — Picks a free port, generates and starts a FastAPI server subprocess, waits for TCP readiness, opens an MCP session via `streamable_http_client`, discovers tools as `AgentWorldModelTool` instances.
-- **`rollout(task)`** — Runs the Strands agent with MCP tools. The agent interacts with the FastAPI server to complete the task.
-- **`cleanup()`** — Clears tools, closes MCP session/transport (`AsyncExitStack`), kills the server process group (SIGTERM, then SIGKILL after 5s timeout), removes the temp dir.
+- **`reset(task)`** — Creates a fresh scratch dir (`mkdtemp`), clones `task.initial_db_path` into it as the working DB (per-episode isolation by construction — concurrent episodes never share mutable state), generates and starts a FastAPI server subprocess on the clone, waits for TCP readiness, opens an MCP session, discovers tools.
+- **`rollout(task)`** — Runs the full episode: `reset`, the agent loop against the MCP tools, reward, `cleanup`.
+- **`cleanup()`** — Clears tools, closes the MCP session/transport, kills the server process group (SIGTERM, then SIGKILL), removes the scratch dir it created.

--- a/src/strands_env/environments/agent_world_model/__init__.py
+++ b/src/strands_env/environments/agent_world_model/__init__.py
@@ -16,11 +16,13 @@
 
 from .env import AgentWorldModelConfig, AgentWorldModelEnv
 from .reward import AgentWorldModelReward
+from .task import AgentWorldModelTask
 from .tool import AgentWorldModelTool
 
 __all__ = [
     "AgentWorldModelConfig",
     "AgentWorldModelEnv",
-    "AgentWorldModelTool",
     "AgentWorldModelReward",
+    "AgentWorldModelTask",
+    "AgentWorldModelTool",
 ]

--- a/src/strands_env/environments/agent_world_model/env.py
+++ b/src/strands_env/environments/agent_world_model/env.py
@@ -22,6 +22,7 @@ import logging
 import random
 import shutil
 import subprocess
+import tempfile
 from datetime import timedelta
 from pathlib import Path
 from typing import NotRequired, Unpack, override
@@ -32,34 +33,30 @@ from mcp.client.streamable_http import streamable_http_client
 
 from strands_env.core.environment import Environment, EnvironmentConfig
 from strands_env.core.models import ModelFactory
-from strands_env.core.types import RewardFunction, Task
 
 from .reward import AgentWorldModelReward
 from .server import kill_server, start_server
+from .task import AgentWorldModelTask
 from .tool import AgentWorldModelTool
 
 logger = logging.getLogger(__name__)
 
 
 class AgentWorldModelConfig(EnvironmentConfig):
-    """Serializable configuration for `AgentWorldModelEnv`."""
+    """Serializable configuration for `AgentWorldModelEnv` (per-task fields ride `AgentWorldModelTask`)."""
 
-    scenario: str
-    envs_path: str
-    work_db_path: str
-    initial_db_path: str
-    temp_dir: str
-    tool_call_timeout: NotRequired[int]
+    envs_path: str  # path to gen_envs.jsonl — the dataset of generated worlds
+    mcp_timeout: NotRequired[int]  # seconds per MCP tool call (default 60)
 
 
-class AgentWorldModelEnv(Environment):
+class AgentWorldModelEnv(Environment[AgentWorldModelTask]):
     """MCP environment backed by an AgentWorldModel FastAPI server subprocess.
 
     Notes:
-        - `reset()` starts a per-task FastAPI server, opens an MCP session,
-          and discovers tools.
-        - `cleanup()` closes the session, kills the server, and removes the
-          temp directory.
+        - `reset(task)` clones the task's DB snapshot into fresh scratch, starts a
+          per-episode FastAPI server on the clone, opens an MCP session, and
+          discovers tools.
+        - `cleanup()` closes the session, kills the server, and removes the scratch dir.
     """
 
     default_system_prompt_path = Path(__file__).parent / "system_prompt.md"
@@ -68,35 +65,47 @@ class AgentWorldModelEnv(Environment):
         self,
         *,
         model_factory: ModelFactory,
-        reward_fn: RewardFunction | None = None,
         http_client: httpx.AsyncClient | None = None,
         **config: Unpack[AgentWorldModelConfig],
     ):
-        """Initialize an `AgentWorldModelEnv` instance."""
-        super().__init__(
-            model_factory=model_factory,
-            reward_fn=reward_fn or AgentWorldModelReward(),
-            **config,  # type: ignore[misc]
-        )
+        """Initialize an `AgentWorldModelEnv` instance.
+
+        Args:
+            model_factory: Factory for the agent's model.
+            http_client: Optional shared HTTP client for the MCP transport.
+            **config: See `AgentWorldModelConfig`.
+        """
+        super().__init__(model_factory=model_factory, **config)  # type: ignore[misc]
+        self.envs_path = Path(str(self.config["envs_path"]))
+        self.mcp_timeout = timedelta(seconds=int(self.config.get("mcp_timeout", 60)))
+        self.temp_dir: Path | None = None
         self._http_client = http_client
-        self._tool_call_timeout = timedelta(seconds=int(self.config.get("tool_call_timeout", 60)))
-        self._scenario: str = str(self.config["scenario"])
-        self._envs_path = Path(str(self.config["envs_path"]))
-        self._work_db_path = Path(str(self.config["work_db_path"]))
-        self._temp_dir = Path(str(self.config["temp_dir"]))
         self._server_proc: subprocess.Popen | None = None
         self._exit_stack: contextlib.AsyncExitStack | None = None
         self._tools: list[AgentWorldModelTool] = []
+        # The reward is tied to the env's working DB, so we don't take it as a parameter.
+        self.reward_fn = AgentWorldModelReward(self)
+
+    @property
+    def work_db_path(self) -> Path | None:
+        """The episode's working DB (a private clone of the task's snapshot); None outside an episode."""
+        return self.temp_dir / "work.db" if self.temp_dir is not None else None
 
     @override
-    async def reset(self, task: Task) -> None:
-        """Start AgentWorldModel server, open MCP session, discover tools."""
+    async def reset(self, task: AgentWorldModelTask) -> None:
+        """Clone the task's DB into fresh scratch, start the server, open an MCP session."""
+        # Per-episode scratch: the working DB is a private copy of the task's pristine
+        # snapshot, so concurrent episodes (e.g. pass@k) never share mutable state.
+        self.temp_dir = Path(await asyncio.to_thread(tempfile.mkdtemp, prefix="awm-"))
+        work_db_path = self.temp_dir / "work.db"
+        await asyncio.to_thread(shutil.copyfile, task.initial_db_path, work_db_path)
+
         await asyncio.sleep(random.uniform(0, 5))  # stagger concurrent server spawns
         self._server_proc, port = await start_server(
-            self._scenario,
-            self._envs_path,
-            self._work_db_path,
-            self._temp_dir,
+            task.scenario,
+            self.envs_path,
+            work_db_path,
+            self.temp_dir,
         )
 
         # Open MCP session and discover tools
@@ -117,7 +126,7 @@ class AgentWorldModelEnv(Environment):
                     tool,
                     session,
                     server_proc=self._server_proc,
-                    timeout=self._tool_call_timeout,
+                    timeout=self.mcp_timeout,
                 )
                 for tool in result.tools
             ]
@@ -143,5 +152,6 @@ class AgentWorldModelEnv(Environment):
             self._exit_stack = None
         await kill_server(self._server_proc)
         self._server_proc = None
-        if self._temp_dir:
-            await asyncio.to_thread(shutil.rmtree, self._temp_dir, True)
+        if self.temp_dir is not None:
+            await asyncio.to_thread(shutil.rmtree, self.temp_dir, True)
+            self.temp_dir = None

--- a/src/strands_env/environments/agent_world_model/reward.py
+++ b/src/strands_env/environments/agent_world_model/reward.py
@@ -14,7 +14,7 @@
 
 """Reward function for AgentWorldModel tasks.
 
-Executes per-task ``verify_task_completion`` via ``exec()`` for binary reward.
+Executes per-task `verify_task_completion` via `exec()` for binary reward.
 """
 
 from __future__ import annotations
@@ -23,60 +23,53 @@ import asyncio
 import json
 import logging
 import sqlite3
-import traceback
-from typing import Any
+from typing import TYPE_CHECKING
 
-from strands_env.core.types import RewardFunction, RewardResult, RolloutResult, Task
+from strands_env.core.types import RewardFunction, RewardResult, RolloutResult
+
+from .task import AgentWorldModelTask
+
+if TYPE_CHECKING:
+    from .env import AgentWorldModelEnv
 
 logger = logging.getLogger(__name__)
 
-OUTCOME_COMPLETED = "COMPLETED"
-OUTCOME_AGENT_FAILED = "AGENT_FAILED"
-OUTCOME_VERIFY_ERROR = "VERIFY_ERROR"
 
-
-class AgentWorldModelReward(RewardFunction):
+class AgentWorldModelReward(RewardFunction[AgentWorldModelTask]):
     """Binary reward via execution-based verification."""
 
-    @staticmethod
-    def _run_verification(verify_code: str, initial_db_path: str, work_db_path: str, final_answer: str) -> dict:
-        """Execute verification code in a thread (blocking exec + SQLite I/O)."""
-        namespace: dict = {"sqlite3": sqlite3, "json": json}
-        exec(verify_code, namespace)  # noqa: S102
-        return namespace["verify_task_completion"](
-            initial_db_path=initial_db_path,
-            final_db_path=work_db_path,
-            final_answer=final_answer,
-        )
+    def __init__(self, env: AgentWorldModelEnv) -> None:
+        """Initialize an `AgentWorldModelReward` instance (the env owns the episode's working DB)."""
+        self._env = env
 
-    async def compute(self, task: Task, result: RolloutResult) -> RewardResult:
-        """Run verification code against the agent's final response."""
-        ctx: Any = task  # AWM task fields (verify_code, db paths, scenario) arrive as Task extras
-        final_answer = result.final_response or ""
+    async def compute(self, task: AgentWorldModelTask, result: RolloutResult) -> RewardResult:
+        """Run the task's verification code against the final DB state and the agent's final response."""
+        work_db_path = self._env.work_db_path
+        assert work_db_path is not None, "reset() has not run"
+
+        # blocking exec + SQLite I/O, shipped to a thread below
+        def _verify() -> dict:
+            namespace: dict = {"sqlite3": sqlite3, "json": json}
+            exec(task.verify_code, namespace)  # noqa: S102
+            return namespace["verify_task_completion"](
+                initial_db_path=task.initial_db_path,
+                final_db_path=str(work_db_path),
+                final_answer=result.final_response or "",
+            )
 
         try:
-            verification = await asyncio.to_thread(
-                self._run_verification,
-                ctx.verify_code,
-                ctx.initial_db_path,
-                ctx.work_db_path,
-                final_answer,
-            )
+            verification = await asyncio.to_thread(_verify)
         except Exception as e:
-            logger.warning("Verification failed for %s task %s: %s", ctx.scenario, ctx.task_idx, e)
+            logger.warning("Verification failed for %s task %s: %s", task.scenario, task.task_idx, e)
             return RewardResult(
                 reward=0.0,
-                info={
-                    "outcome": OUTCOME_VERIFY_ERROR,
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                    "traceback": traceback.format_exception_only(type(e), e)[-1].strip(),
-                },
+                info={"status": "error", "error": str(e), "error_type": type(e).__name__},
             )
 
+        # status is "success" whenever the verifier RAN — reward 0.0 means the agent failed the
+        # task, not the pipeline (the same contract as the other envs; evaluators retry on error).
         is_complete = isinstance(verification, dict) and verification.get("result") == "complete"
-        outcome = OUTCOME_COMPLETED if is_complete else OUTCOME_AGENT_FAILED
-        logger.info("Verification %s task %d: %s (outcome=%s)", ctx.scenario, ctx.task_idx, verification, outcome)
+        logger.info("Verification %s task %d: %s", task.scenario, task.task_idx, verification)
         return RewardResult(
-            reward=1.0 if is_complete else 0.0, info={"outcome": outcome, "verification_result": verification}
+            reward=1.0 if is_complete else 0.0, info={"status": "success", "verification_result": verification}
         )

--- a/src/strands_env/environments/agent_world_model/task.py
+++ b/src/strands_env/environments/agent_world_model/task.py
@@ -1,0 +1,32 @@
+# Copyright 2025-2026 Strands RL Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The per-sample input type for `AgentWorldModelEnv`."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from strands_env.core import Task
+
+
+class AgentWorldModelTask(Task):
+    """Rollout input for `AgentWorldModelEnv`."""
+
+    scenario: str = Field(description="Scenario name in `gen_envs.jsonl` (which synthetic world to boot).")
+    task_idx: int = Field(description="Task index within the scenario (used in logs).")
+    verify_code: str = Field(description="Python source defining `verify_task_completion(...)`.")
+    initial_db_path: str = Field(
+        description="Pristine SQLite snapshot for this scenario; the episode's working DB is cloned from it."
+    )


### PR DESCRIPTION
## Summary

The AWM slice of the payload migration, mirroring harbor (#180):

**`AgentWorldModelTask`** — `scenario` / `task_idx` / `verify_code` / `initial_db_path`, pure data. (A `run_verification` method briefly lived here; moved back to the reward per the design rule this PR series crystallized: tasks may own *data-derived views* of their own fields, never *scoring behavior*.)

**`AgentWorldModelConfig`** — shrinks to `envs_path` + `tool_call_timeout`. The old contract required the same values injected **twice**: once into config for the env, once as untyped Task extras for the reward (read through an `Any` cast).

**Env-derived scratch** — `reset(task)` creates a fresh `mkdtemp` and **clones the task's DB snapshot** into it as the episode's working DB: pass@k isolation by construction, and `cleanup()` now only removes a dir it created (it used to `rmtree` an injected path). `work_db_path` is a single-source property over `temp_dir` (`None` outside an episode).

**Reward** — built in and tied to the env's working DB (dead `reward_fn` parameter removed, harbor precedent); typed `RewardFunction[AgentWorldModelTask]`; the `OUTCOME_*` constants and `outcome` info key are gone — derivable from `(reward, status)`, and the shape violated the house `status=success/error` contract that evaluator retry policies key on.

**Breaking**: env construction is capability-only; the sample arrives as `AgentWorldModelTask` via `rollout(task)`. No consumers existed in either repo (verified), so nothing else changes.

## Test plan

238 unit tests, mypy strict, ruff + format; task JSON round-trip and the verification `exec` path exercised live against a real SQLite pair; capability-only construction smoke-tested (awm dep installed in the dev venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)