### PR TITLE
refactor(core)!: zero-arg AsyncEnvFactory + auto-derived task_cls

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -109,7 +109,7 @@ def create_env_factory(model_config: dict, **env_config):
     """Create an async environment factory."""
     model_factory = build_model_factory(model_config)
 
-    async def env_factory(task):
+    async def env_factory():
         return YourEnvironment(model_factory=model_factory, **env_config)
 
     return env_factory
@@ -127,7 +127,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     reward_fn = MathVerifyReward()
 
-    async def env_factory(_task):
+    async def env_factory():
         return CalculatorEnv(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory
@@ -145,7 +145,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     reward_fn = MathVerifyReward()
 
-    async def env_factory(_task):
+    async def env_factory():
         return AgentCoreCodeEnv(model_factory=model_factory, reward_fn=reward_fn, mode="code", **env_config)
 
     return env_factory

--- a/examples/eval/aime/agentcore_code_env.py
+++ b/examples/eval/aime/agentcore_code_env.py
@@ -29,7 +29,7 @@ def create_env_factory(model_config: dict, **env_config):
     reward_fn = MathVerifyReward()
     client = get_client(service_name="bedrock-agentcore", role_arn=env_config.get("agentcore_role_arn"))
 
-    async def env_factory(_task):
+    async def env_factory():
         return AgentCoreCodeEnv(
             model_factory=model_factory, reward_fn=reward_fn, mode="code", client=client, quotas=QUOTAS, **env_config
         )

--- a/examples/eval/aime/chat_env.py
+++ b/examples/eval/aime/chat_env.py
@@ -24,7 +24,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     reward_fn = MathVerifyReward()
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/browsecomp/chat_env.py
+++ b/examples/eval/browsecomp/chat_env.py
@@ -37,7 +37,7 @@ def create_env_factory(model_config: dict, **env_config):
         )
     reward_fn = BrowseCompReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/browsecomp/web_search_env.py
+++ b/examples/eval/browsecomp/web_search_env.py
@@ -42,7 +42,7 @@ def create_env_factory(model_config: dict, **env_config):
         )
     reward_fn = BrowseCompReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
 
-    async def env_factory(_task):
+    async def env_factory():
         return WebSearchEnv(
             model_factory=model_factory,
             reward_fn=reward_fn,

--- a/examples/eval/frames/chat_env.py
+++ b/examples/eval/frames/chat_env.py
@@ -37,7 +37,7 @@ def create_env_factory(model_config: dict, **env_config):
         )
     reward_fn = FramesReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/gpqa/agentcore_code_env.py
+++ b/examples/eval/gpqa/agentcore_code_env.py
@@ -29,7 +29,7 @@ def create_env_factory(model_config: dict, **env_config):
     reward_fn = GPQAReward()
     client = get_client(service_name="bedrock-agentcore", role_arn=env_config.get("agentcore_role_arn"))
 
-    async def env_factory(_task):
+    async def env_factory():
         return AgentCoreCodeEnv(
             model_factory=model_factory, reward_fn=reward_fn, mode="code", client=client, quotas=QUOTAS, **env_config
         )

--- a/examples/eval/gpqa/chat_env.py
+++ b/examples/eval/gpqa/chat_env.py
@@ -24,7 +24,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     reward_fn = GPQAReward()
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/hle_verified/chat_env.py
+++ b/examples/eval/hle_verified/chat_env.py
@@ -43,7 +43,7 @@ def create_env_factory(model_config: dict, **env_config):
         )
     reward_fn = HLEReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/hmmt/agentcore_code_env.py
+++ b/examples/eval/hmmt/agentcore_code_env.py
@@ -24,7 +24,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     reward_fn = MathVerifyReward()
 
-    async def env_factory(_task):
+    async def env_factory():
         return AgentCoreCodeEnv(model_factory=model_factory, reward_fn=reward_fn, mode="code", **env_config)
 
     return env_factory

--- a/examples/eval/hmmt/chat_env.py
+++ b/examples/eval/hmmt/chat_env.py
@@ -24,7 +24,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     reward_fn = MathVerifyReward()
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/ifeval/chat_env.py
+++ b/examples/eval/ifeval/chat_env.py
@@ -24,7 +24,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     reward_fn = IFEvalReward(metric=env_config.pop("ifeval_metric", "prompt_level_strict_acc"))
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/mcp_atlas/env.py
+++ b/examples/eval/mcp_atlas/env.py
@@ -39,7 +39,7 @@ def create_env_factory(model_config: dict, **env_config):
     docker_url = env_config.get("docker_url", MCPAtlasEnv.DEFAULT_DOCKER_URL)
     http_client = MCPAtlasEnv.create_client(base_url=docker_url)
 
-    async def env_factory(_task):
+    async def env_factory():
         # Each env gets its own reward_fn to avoid concurrent tasks overwriting
         # _current_claim / _response on a shared instance.
         reward_fn = MCPAtlasReward(judge_model=judge_models, max_model_retries=max_judge_retries)

--- a/examples/eval/sealqa/chat_env.py
+++ b/examples/eval/sealqa/chat_env.py
@@ -37,7 +37,7 @@ def create_env_factory(model_config: dict, **env_config):
         )
     reward_fn = SealQAReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/simple_math/calculator_env.py
+++ b/examples/eval/simple_math/calculator_env.py
@@ -24,7 +24,7 @@ def create_env_factory(model_config: dict, **env_config):
     model_factory = build_model_factory(model_config)
     reward_fn = MathVerifyReward()
 
-    async def env_factory(_task):
+    async def env_factory():
         return CalculatorEnv(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/simpleqa_verified/chat_env.py
+++ b/examples/eval/simpleqa_verified/chat_env.py
@@ -37,7 +37,7 @@ def create_env_factory(model_config: dict, **env_config):
         )
     reward_fn = SimpleQAReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
 
-    async def env_factory(_task):
+    async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)
 
     return env_factory

--- a/examples/eval/swe_bench/swe_bench_env.py
+++ b/examples/eval/swe_bench/swe_bench_env.py
@@ -21,7 +21,6 @@ into each task's config, so this hook just instantiates the generic `HarborEnv`.
 from __future__ import annotations
 
 from strands_env.core.models import build_model_factory
-from strands_env.core.types import Task
 from strands_env.environments.harbor import HarborEnv
 
 
@@ -29,7 +28,7 @@ def create_env_factory(model_config: dict, **env_config):
     """Create env_factory for `HarborEnv`."""
     model_factory = build_model_factory(model_config)
 
-    async def env_factory(_task: Task) -> HarborEnv:
+    async def env_factory() -> HarborEnv:
         """Create a new HarborEnv with its own container/pod. The sample itself arrives via `rollout(task)`."""
         return HarborEnv(model_factory=model_factory, **env_config)
 

--- a/examples/eval/tau2_bench/tau2_bench_env.py
+++ b/examples/eval/tau2_bench/tau2_bench_env.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 from typing import Any
 
 from strands_env.core.models import build_model_factory
-from strands_env.core.types import Task
 from strands_env.environments.tau2_bench import Tau2BenchEnv
 
 #: Default model for the user-simulator and NL-assertion judge (override via ``--env-config``).
@@ -44,7 +43,7 @@ def create_env_factory(model_config: dict, **env_config: Any):
     judge_config = env_config.pop("judge_model_config", DEFAULT_USER_JUDGE_MODEL_CONFIG)
     judge_model_factory = build_model_factory(judge_config) if judge_config else None
 
-    async def env_factory(_task: Task) -> Tau2BenchEnv:
+    async def env_factory() -> Tau2BenchEnv:
         """Construct a fresh `Tau2BenchEnv` (the sample itself arrives via `rollout(task)`)."""
         return Tau2BenchEnv(
             agent_model_factory=agent_model_factory,

--- a/examples/eval/terminal_bench/terminal_bench_env.py
+++ b/examples/eval/terminal_bench/terminal_bench_env.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from strands_env.core.models import build_model_factory
-from strands_env.core.types import Task
 from strands_env.environments.harbor import HarborEnv
 
 
@@ -25,7 +24,7 @@ def create_env_factory(model_config: dict, **env_config):
     """Create env_factory for `HarborEnv`."""
     model_factory = build_model_factory(model_config)
 
-    async def env_factory(_task: Task) -> HarborEnv:
+    async def env_factory() -> HarborEnv:
         """Create a new HarborEnv with its own Docker container. The sample itself arrives via `rollout(task)`."""
         return HarborEnv(model_factory=model_factory, **env_config)
 

--- a/src/strands_env/core/distributed.py
+++ b/src/strands_env/core/distributed.py
@@ -60,8 +60,8 @@ class EnvironmentActor:
         Returns:
             JSON string, reconstruct via `RolloutResult.model_validate_json()`.
         """
-        task = Task.model_validate_json(task_json)
         env = await self.env_factory()
+        task = env.task_cls.model_validate_json(task_json)  # restore the env's typed task from the wire
         result = await env.rollout(task)
         return result.model_dump_json()
 
@@ -75,9 +75,9 @@ class EnvironmentActor:
         Returns:
             JSON string, reconstruct via `RewardResult.model_validate_json()`.
         """
-        task = Task.model_validate_json(task_json)
         result = RolloutResult.model_validate_json(result_json)
         env = await self.env_factory()
+        task = env.task_cls.model_validate_json(task_json)  # restore the env's typed task from the wire
         try:
             if env.reward_fn is None:
                 raise ValueError("Environment has no reward function configured")

--- a/src/strands_env/core/distributed.py
+++ b/src/strands_env/core/distributed.py
@@ -61,7 +61,7 @@ class EnvironmentActor:
             JSON string, reconstruct via `RolloutResult.model_validate_json()`.
         """
         task = Task.model_validate_json(task_json)
-        env = await self.env_factory(task)
+        env = await self.env_factory()
         result = await env.rollout(task)
         return result.model_dump_json()
 
@@ -77,7 +77,7 @@ class EnvironmentActor:
         """
         task = Task.model_validate_json(task_json)
         result = RolloutResult.model_validate_json(result_json)
-        env = await self.env_factory(task)
+        env = await self.env_factory()
         try:
             if env.reward_fn is None:
                 raise ValueError("Environment has no reward function configured")

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -20,7 +20,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import Any, ClassVar, Generic, Unpack
+from typing import Any, ClassVar, Generic, Unpack, get_args, get_origin
 
 from opentelemetry.util.types import AttributeValue
 from strands import Agent
@@ -34,6 +34,7 @@ from .models import ModelFactory
 from .types import (
     RewardFunction,
     RolloutResult,
+    Task,
     TaskT,
     TerminationReason,
 )
@@ -64,6 +65,18 @@ class Environment(Generic[TaskT]):
     """Base RL rollout environment for Strands agents."""
 
     default_system_prompt_path: ClassVar[Path | None] = None
+    #: Concrete task type, auto-derived from the generic parametrization (see `__init_subclass__`).
+    task_cls: ClassVar[type[Task]] = Task
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Derive `task_cls` from `class XxxEnv(Environment[XxxTask])` — one declaration, no drift."""
+        super().__init_subclass__(**kwargs)
+        for base in getattr(cls, "__orig_bases__", ()):
+            origin = get_origin(base)
+            if isinstance(origin, type) and issubclass(origin, Environment):
+                (arg,) = get_args(base)
+                if isinstance(arg, type) and issubclass(arg, Task):
+                    cls.task_cls = arg
 
     def __init__(
         self,

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -40,8 +40,8 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
-#: Type alias for environment factory function (async).
-type AsyncEnvFactory = Callable[[Any], Awaitable["Environment[Any]"]]
+#: Zero-arg async environment factory; the sample arrives via `rollout(task)`.
+type AsyncEnvFactory = Callable[[], Awaitable["Environment[Any]"]]
 
 
 class EnvironmentConfig(TypedDict, total=False):

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -64,17 +64,19 @@ class EnvironmentConfig(TypedDict, total=False):
 class Environment(Generic[TaskT]):
     """Base RL rollout environment for Strands agents."""
 
-    default_system_prompt_path: ClassVar[Path | None] = None
-    #: Concrete task type, auto-derived from the generic parametrization (see `__init_subclass__`).
     task_cls: ClassVar[type[Task]] = Task
+    default_system_prompt_path: ClassVar[Path | None] = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Derive `task_cls` from `class XxxEnv(Environment[XxxTask])` — one declaration, no drift."""
         super().__init_subclass__(**kwargs)
+        # `__orig_bases__` keeps the unerased `Environment[XxxTask]` (absent for plain
+        # subclasses, which then inherit the parent's task_cls)
         for base in getattr(cls, "__orig_bases__", ()):
             origin = get_origin(base)
             if isinstance(origin, type) and issubclass(origin, Environment):
                 (arg,) = get_args(base)
+                # skip TypeVars: a generic intermediate layer must not overwrite task_cls
                 if isinstance(arg, type) and issubclass(arg, Task):
                     cls.task_cls = arg
 

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -70,15 +70,13 @@ class Environment(Generic[TaskT]):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Derive `task_cls` from `class XxxEnv(Environment[XxxTask])` — one declaration, no drift."""
         super().__init_subclass__(**kwargs)
-        # `__orig_bases__` keeps the unerased `Environment[XxxTask]` (absent for plain
-        # subclasses, which then inherit the parent's task_cls)
+        # `__orig_bases__` keeps the unerased `Environment[XxxTask]`
         for base in getattr(cls, "__orig_bases__", ()):
             origin = get_origin(base)
             if isinstance(origin, type) and issubclass(origin, Environment):
-                (arg,) = get_args(base)
-                # skip TypeVars: a generic intermediate layer must not overwrite task_cls
-                if isinstance(arg, type) and issubclass(arg, Task):
-                    cls.task_cls = arg
+                for arg in get_args(base):
+                    if isinstance(arg, type) and issubclass(arg, Task):
+                        cls.task_cls = arg
 
     def __init__(
         self,
@@ -157,6 +155,7 @@ class Environment(Generic[TaskT]):
             trace_attributes=self.trace_attributes or None,
             name=self.agent_name,
         )
+
         # 2. Run the agent loop.
         error = None
         try:

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -169,7 +169,7 @@ class Evaluator(Generic[TaskT]):
                 result = await self.env_actor_pool.rollout(task)
             else:
                 assert self.env_factory is not None
-                env = await self.env_factory(task)
+                env = await self.env_factory()
                 result = await env.rollout(task)
             # Clean up the token-level rollout if not needed to reduce verbosity
             if not self.keep_rollout:

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -336,3 +336,48 @@ class TestEnvironmentConfigTypeHints:
 
         hints = typing.get_type_hints(EnvironmentConfig)
         assert "trace_attributes" in hints
+
+
+class TestTaskCls:
+    """task_cls auto-derivation from the generic parametrization."""
+
+    def test_derived_from_parametrization(self):
+        class MyTask(Task):
+            flavor: str = "x"
+
+        class MyEnv(Environment[MyTask]):
+            pass
+
+        assert MyEnv.task_cls is MyTask
+
+    def test_inherited_by_unparametrized_subclass(self):
+        class MyTask(Task):
+            pass
+
+        class MyEnv(Environment[MyTask]):
+            pass
+
+        class MySubEnv(MyEnv):
+            pass
+
+        assert MySubEnv.task_cls is MyTask
+
+    def test_bare_env_defaults_to_task(self):
+        class BareEnv(Environment):
+            pass
+
+        assert BareEnv.task_cls is Task
+
+    def test_wire_round_trip_restores_typed_task(self):
+        """The actor-side pattern: env.task_cls revives the typed sample from JSON."""
+
+        class MyTask(Task):
+            payload: int
+
+        class MyEnv(Environment[MyTask]):
+            pass
+
+        task = MyTask(message="q", payload=7)
+        revived = MyEnv.task_cls.model_validate_json(task.model_dump_json())
+        assert isinstance(revived, MyTask)
+        assert revived.payload == 7

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -368,6 +368,28 @@ class TestTaskCls:
 
         assert BareEnv.task_cls is Task
 
+    def test_multi_param_generic_layer(self):
+        """A multi-parameter generic env layer must neither crash nor mis-derive."""
+        from typing import Generic, TypeVar
+
+        from strands_env.core.types import TaskT
+
+        class MyTask(Task):
+            pass
+
+        fmt = TypeVar("fmt")
+
+        # fmt precedes TaskT: a defaulted TypeVar cannot be followed by a non-defaulted
+        # one (PEP 696) — same ordering reason as LLMJudgeReward[JudgmentFormat, TaskT]
+        class Middle(Environment[TaskT], Generic[fmt, TaskT]):
+            pass
+
+        class Leaf(Middle[str, MyTask]):
+            pass
+
+        assert Middle.task_cls is Task  # TypeVars filtered
+        assert Leaf.task_cls is MyTask  # picked out of the two args
+
     def test_wire_round_trip_restores_typed_task(self):
         """The actor-side pattern: env.task_cls revives the typed sample from JSON."""
 

--- a/tests/unit/eval/test_evaluator.py
+++ b/tests/unit/eval/test_evaluator.py
@@ -36,7 +36,7 @@ class TestEvaluator:
         """Factory mode: rollout() called once per sample (it owns reset/cleanup internally)."""
         mock_env.rollout.return_value = RolloutResult()
 
-        async def factory(task):
+        async def factory():
             return mock_env
 
         tasks = [Task(id=f"p{i}", message=f"q{i}") for i in range(3)]
@@ -52,7 +52,7 @@ class TestEvaluator:
         """Each task is duplicated n_samples_per_prompt times."""
         mock_env.rollout.return_value = RolloutResult()
 
-        async def factory(task):
+        async def factory():
             return mock_env
 
         tasks = [Task(id="p1", message="q")]
@@ -68,16 +68,17 @@ class TestEvaluator:
         sample_ids = [s.task.id for s in results["p1"]]
         assert len(set(sample_ids)) == 5
 
-    async def test_factory_receives_task(self, tmp_path):
-        """Factory receives the task for per-sample configuration."""
+    async def test_task_flows_to_rollout(self, tmp_path):
+        """The factory is zero-arg; the sample reaches the env via `rollout(task)`."""
         received_tasks = []
 
-        async def factory(task):
+        async def rollout(task):
             received_tasks.append(task)
+            return RolloutResult()
+
+        async def factory():
             env = MagicMock()
-            env.reset = AsyncMock()
-            env.rollout = AsyncMock(return_value=RolloutResult())
-            env.cleanup = AsyncMock()
+            env.rollout = AsyncMock(side_effect=rollout)
             return env
 
         tasks = [Task(message="q1"), Task(message="q2")]
@@ -103,7 +104,7 @@ class TestEvaluator:
             concurrent_count -= 1
             return RolloutResult()
 
-        async def factory(task):
+        async def factory():
             env = MagicMock()
             env.reset = AsyncMock()
             env.rollout = mock_rollout
@@ -120,7 +121,7 @@ class TestEvaluator:
     async def test_empty_tasks(self, mock_env, tmp_path):
         """Empty tasks produces empty results."""
 
-        async def factory(task):
+        async def factory():
             return mock_env
 
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
@@ -135,7 +136,7 @@ class TestEvaluator:
         rollout.add_prompt([1])
         rollout.add_response([2, 3], logprobs=[-0.5, -0.3])
 
-        async def factory(task):
+        async def factory():
             env = MagicMock()
             env.reset = AsyncMock()
             env.rollout = AsyncMock(
@@ -152,7 +153,7 @@ class TestEvaluator:
     async def test_rollout_error_aborts_sample(self, tmp_path):
         """A raising rollout() marks the sample aborted (cleanup guarantee lives in Environment.rollout)."""
 
-        async def factory(task):
+        async def factory():
             env = MagicMock()
             env.rollout = AsyncMock(side_effect=RuntimeError("rollout failed"))
             return env
@@ -173,7 +174,7 @@ class TestCheckpoint:
         mock_env.rollout.return_value = RolloutResult()
         output_path = tmp_path / "results.jsonl"
 
-        async def factory(task):
+        async def factory():
             return mock_env
 
         evaluator = Evaluator(env_factory=factory, output_path=output_path, save_interval=1)
@@ -188,7 +189,7 @@ class TestCheckpoint:
         mock_env.rollout.return_value = RolloutResult()
         output_path = tmp_path / "results.jsonl"
 
-        async def factory(task):
+        async def factory():
             return mock_env
 
         # First run - complete s1
@@ -225,7 +226,7 @@ class TestValidateSample:
             "p3": [make_sample(0.0, 4, aborted=True)],
         }
 
-        async def factory(task):
+        async def factory():
             return MagicMock()
 
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
@@ -242,7 +243,7 @@ class TestValidateSample:
             def validate_sample(self, sample):
                 return False
 
-        async def factory(task):
+        async def factory():
             nonlocal rollout_count
             rollout_count += 1
             env = MagicMock()
@@ -273,7 +274,7 @@ class TestValidateSample:
             "p2": [make_sample(1.0, 2)],
         }
 
-        async def factory(task):
+        async def factory():
             return MagicMock()
 
         evaluator = Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
@@ -292,7 +293,7 @@ class TestValidateSample:
 
         call_count = 0
 
-        async def factory(task):
+        async def factory():
             nonlocal call_count
             call_count += 1
             reward = RewardResult(reward=1.0) if call_count == 2 else None
@@ -327,7 +328,7 @@ class TestComputeMetrics:
     async def test_default_metrics(self, tmp_path):
         """Default metric_fns includes pass@k."""
 
-        async def factory(task):
+        async def factory():
             env = MagicMock()
             env.reset = AsyncMock()
             env.rollout = AsyncMock(
@@ -438,7 +439,7 @@ class TestDistributedEvaluation:
         mock_pool.rollout = AsyncMock(return_value=RolloutResult())
         factory_called = False
 
-        async def factory(task):
+        async def factory():
             nonlocal factory_called
             factory_called = True
 


### PR DESCRIPTION
## Summary

The finale of the lifecycle-v2 series — with every payload migration landed (tau2 #170-176, harbor #180/#182, AWM #186), the two runtime seams can close:

**Zero-arg factory** (breaking): `AsyncEnvFactory = Callable[[], Awaitable[Environment[Any]]]`. The task parameter existed so factories could move `task.config` into constructors; after the migrations all 18 example factories ignored it — pure ceremony. Capability config lives in the closure, symmetric with `ModelFactory`; the sample arrives via `rollout(task)`.

**`task_cls` — the runtime face of `TaskT`**: generics are erased at runtime, so the Ray actor deserialized every task to base `Task`, silently dropping typed-task properties (`Tau2BenchTask.tau2_task`, `HarborTask.task_paths`) on the distributed path. `Environment.__init_subclass__` now derives `task_cls` from the generic parametrization itself (`class HarborEnv(Environment[HarborTask])` → `task_cls = HarborTask`) — **one declaration, no drift**, cached at class creation rather than introspected per call. The actor builds the env first, then revives the typed sample with `env.task_cls.model_validate_json()`.

## Test plan

242 unit tests (4 new: parametrized / inherited / bare-default / wire round-trip), mypy strict, ruff + format; all six envs verified to derive the correct task class at import; docs and 18 example factories updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)