### PR TITLE
chore: declare the real extra conflict (harbor vs agent-world-model)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,10 @@ ignore_missing_imports = true
 
 [tool.uv]
 conflicts = [
+    # agent-world-model==0.1.0 pins fastapi==0.115.12; harbor>=0.14.0 needs fastapi>=0.128.0
     [
-        { extra = "litellm" },
         { extra = "harbor" },
+        { extra = "agent-world-model" },
     ],
 ]
 


### PR DESCRIPTION
Resolver-tested all extra pairs (`uv pip compile`, clean resolution): `harbor+litellm` resolves fine today — the declared conflict was stale. The pair that truly cannot coexist is `harbor` vs `agent-world-model`: awm 0.1.0 pins `fastapi==0.115.12` against harbor's `fastapi>=0.128.0`. Installing both into one env (uv pip install does not re-verify installed constraints) silently corrupts it — bitten in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)