### PR TITLE
feat(core): raw think-block access + get_system_prompt hook on LLMJudgeReward

### DIFF
--- a/src/strands_env/core/llm_judge_reward.py
+++ b/src/strands_env/core/llm_judge_reward.py
@@ -91,19 +91,35 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
         """Get reward from judgment (structured or text)."""
         raise NotImplementedError("Subclasses must implement this method.")
 
+    async def get_system_prompt(self, task: TaskT, result: RolloutResult) -> str | None:
+        """Return the system prompt for the judge. Override for per-sample prompts."""
+        return self.system_prompt
+
     @override
     async def compute(self, task: TaskT, result: RolloutResult) -> RewardResult:
+        # Render system prompt
+        try:
+            system_prompt = await self.get_system_prompt(task, result)
+        except Exception as e:
+            logger.error("System prompt rendering failed: %s", e)
+            return RewardResult(
+                reward=self.default_reward,
+                info={"status": "error", "error_type": "system_prompt_error", "error": str(e)},
+            )
+
+        # Render judge prompt
         try:
             prompt = await self.get_judge_prompt(task, result)
         except Exception as e:
             logger.error("Judge prompt rendering failed: %s", e)
             return RewardResult(
                 reward=self.default_reward,
-                info={"status": "error", "error_type": "prompt_error", "error": str(e)},
+                info={"status": "error", "error_type": "judge_prompt_error", "error": str(e)},
             )
 
+        # Invoke judge model with retry
         for attempt in range(self.max_model_retries):
-            agent = Agent(model=next(self.judge_models), system_prompt=self.system_prompt, tools=[])
+            agent = Agent(model=next(self.judge_models), system_prompt=system_prompt, tools=[])
             try:
                 if self.judgment_format is not None:
                     judgment: JudgmentFormat | str = await agent.structured_output_async(
@@ -125,6 +141,7 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
                     info={"status": "error", "error_type": "judge_error", "error": str(e)},
                 )
 
+        # Get reward
         try:
             reward = await self.get_reward(judgment)
         except Exception as e:
@@ -134,5 +151,6 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
                 info={"status": "error", "error_type": "reward_error", "error": str(e)},
             )
 
+        # Return reward result
         judgment_data = judgment.model_dump() if isinstance(judgment, BaseModel) else judgment
         return RewardResult(reward=reward, info={"status": "success", "judgment": judgment_data})

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -175,32 +175,44 @@ class RolloutResult(BaseModel):
 
     @property
     def final_response(self) -> str | None:
+        """Return text from the last assistant message, with think blocks stripped."""
+        return self.get_final_response(raw=False)
+
+    def get_final_response(self, *, raw: bool = False) -> str | None:
         """Return text from the last assistant message, or None.
+
+        Args:
+            raw: If True, return the full text including <think>...</think> blocks.
+                 If False (default), strip think blocks before returning.
 
         None when the conversation ended on a non-assistant message (e.g. a tau2
         `user_stop` turn) — the agent did not have the last word.
         """
         if not self.messages or self.messages[-1].get("role") != "assistant":
             return None
-        return extract_message_text(self.messages[-1]) or None
+        return extract_message_text(self.messages[-1], raw=raw) or None
 
 
-def extract_message_text(message: Message) -> str:
-    """Extract the final text from a message: the last text block, with any think block stripped.
+def extract_message_text(message: Message, *, raw: bool = False) -> str:
+    """Extract the final text from a message: the last text block.
+
+    Args:
+        message: A strands Message dict.
+        raw: If True, return the full text including `<think>...</think>` blocks.
+            If False (default), strip think blocks before returning.
 
     Returns an empty string when the message contains no text block.
     An unclosed `<think>` block (truncated generation) is returned as-is.
     """
     content = message.get("content") or []
-    # Take the last text block — the final textual output.
     text = next(
         (block["text"] for block in reversed(content) if isinstance(block, dict) and "text" in block),
         None,
     )
     if text is None:
         return ""
-    # Strip think block if any: keep only what follows the last closing tag
-    think_end = text.rfind("</think>")
-    if think_end != -1:
-        text = text[think_end + len("</think>") :].lstrip()
+    if not raw:
+        think_end = text.rfind("</think>")
+        if think_end != -1:
+            text = text[think_end + len("</think>") :].lstrip()
     return text

--- a/tests/unit/core/test_llm_judge_reward.py
+++ b/tests/unit/core/test_llm_judge_reward.py
@@ -71,7 +71,7 @@ def _task_and_result():
 
 class TestErrorRecovery:
     async def test_prompt_error_returns_default_reward(self):
-        """get_judge_prompt raising returns default_reward with prompt_error info."""
+        """get_judge_prompt raising returns default_reward with judge_prompt_error info."""
 
         class _FailingPrompt(LLMJudgeReward):
             judgment_format = None
@@ -87,7 +87,58 @@ class TestErrorRecovery:
         result = await judge.compute(task, result)
 
         assert result.reward == 0.0
-        assert result.info["error_type"] == "prompt_error"
+        assert result.info["error_type"] == "judge_prompt_error"
+
+    async def test_system_prompt_error_returns_default_reward(self):
+        """get_system_prompt raising returns default_reward with system_prompt_error info."""
+
+        class _FailingSystemPrompt(LLMJudgeReward):
+            judgment_format = None
+
+            async def get_judge_prompt(self, task, result):
+                return "prompt"
+
+            async def get_system_prompt(self, task, result):
+                raise RuntimeError("cannot render system prompt")
+
+            async def get_reward(self, judgment):
+                return 1.0
+
+        judge = _FailingSystemPrompt(judge_model=MagicMock(), default_reward=0.0)
+        task, result = _task_and_result()
+        result = await judge.compute(task, result)
+
+        assert result.reward == 0.0
+        assert result.info["error_type"] == "system_prompt_error"
+
+    @patch("strands_env.core.llm_judge_reward.Agent")
+    async def test_get_system_prompt_override_used(self, mock_agent_cls):
+        """Overridden get_system_prompt is forwarded to the Agent constructor."""
+        mock_agent_instance = MagicMock()
+        mock_result = MagicMock()
+        mock_result.message = {"content": [{"text": "correct"}]}
+        mock_agent_instance.invoke_async = AsyncMock(return_value=mock_result)
+        mock_agent_cls.return_value = mock_agent_instance
+
+        class _DynamicPromptJudge(LLMJudgeReward):
+            judgment_format = None
+
+            async def get_judge_prompt(self, task, result):
+                return "grade this"
+
+            async def get_system_prompt(self, task, result):
+                return f"You are judging task {task.id}"
+
+            async def get_reward(self, judgment):
+                return 1.0
+
+        judge = _DynamicPromptJudge(judge_model=MagicMock())
+        task, result = _task_and_result()
+        await judge.compute(task, result)
+
+        # Verify the dynamic system prompt was passed to Agent
+        call_kwargs = mock_agent_cls.call_args[1]
+        assert call_kwargs["system_prompt"].startswith("You are judging task")
 
     @patch("strands_env.core.llm_judge_reward.Agent")
     async def test_judge_error_returns_default_reward(self, mock_agent_cls):

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -93,6 +93,14 @@ class TestExtractMessageText:
         message = {"role": "assistant", "content": [{"text": "<think>truncated mid-thought"}]}
         assert extract_message_text(message) == "<think>truncated mid-thought"
 
+    def test_raw_preserves_think_block(self):
+        message = {"role": "assistant", "content": [{"text": "<think>reasoning</think>Answer"}]}
+        assert extract_message_text(message, raw=True) == "<think>reasoning</think>Answer"
+
+    def test_raw_false_strips_think_block(self):
+        message = {"role": "assistant", "content": [{"text": "<think>reasoning</think>Answer"}]}
+        assert extract_message_text(message, raw=False) == "Answer"
+
 
 # ---------------------------------------------------------------------------
 # RolloutResult
@@ -127,6 +135,18 @@ class TestRolloutResult:
         ]
         result = RolloutResult(messages=messages)
         assert result.final_response == "final answer"
+
+    def test_get_final_response_raw_preserves_think(self):
+        messages = [
+            {"role": "assistant", "content": [{"text": "<think>reasoning</think>The answer is 4."}]},
+        ]
+        result = RolloutResult(messages=messages)
+        assert result.get_final_response(raw=True) == "<think>reasoning</think>The answer is 4."
+        assert result.get_final_response(raw=False) == "The answer is 4."
+
+    def test_get_final_response_no_assistant_returns_none(self):
+        result = RolloutResult(messages=[{"role": "user", "content": [{"text": "hi"}]}])
+        assert result.get_final_response(raw=True) is None
 
     def test_final_response_no_assistant(self):
         messages = [{"role": "user", "content": [{"text": "hi"}]}]


### PR DESCRIPTION
## Summary

Two additive, backward-compatible enhancements to core types and the LLM judge reward:

- **`extract_message_text(message, *, raw=False)`** and **`RolloutResult.get_final_response(*, raw=False)`** — when `raw=True`, return the full text including `<think>...</think>` blocks. RLVR rewards (e.g. format-verification) need the unstripped output to score whether the model produced the expected reasoning structure. The existing `final_response` property keeps its current behavior (strip think blocks).

- **`LLMJudgeReward.get_system_prompt(task, result)`** — a virtual method (default: return `self.system_prompt`) that subclasses can override to produce per-sample judge system prompts (e.g. rubric-per-sample evaluation). Also renames the existing `prompt_error` → `judge_prompt_error` for clarity alongside the new `system_prompt_error` path.

Both are backward-compatible: no existing code changes behavior.

## Test plan

- [x] New unit tests for `extract_message_text(raw=True/False)` and `get_final_response(raw=True/False)`
- [x] New unit tests for `get_system_prompt` override and `system_prompt_error` path
- [x] Existing tests updated for `judge_prompt_error` rename
- [x] Full unit suite passes (220 tests, excluding pre-existing harbor import issue)
- [x] ruff check + format clean