### PR TITLE
fix(harbor): adapt to harbor 0.15 (drop removed ServiceVolumeConfig)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
 ]
 litellm = ["litellm"]
 harbor = [
-    "harbor>=0.14.0",
+    "harbor>=0.15.0",
     "e2b==2.25.1",
 ]
 ifeval = ["lm_eval[ifeval]>=0.4.11"]
@@ -84,7 +84,7 @@ ignore_missing_imports = true
 
 [tool.uv]
 conflicts = [
-    # agent-world-model==0.1.0 pins fastapi==0.115.12; harbor>=0.14.0 needs fastapi>=0.128.0
+    # agent-world-model==0.1.0 pins fastapi==0.115.12; harbor>=0.15.0 needs fastapi>=0.128.0
     [
         { extra = "harbor" },
         { extra = "agent-world-model" },

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -26,8 +26,6 @@ from typing import TYPE_CHECKING, Literal, NotRequired, Unpack, override
 
 from harbor.environments.factory import EnvironmentFactory
 from harbor.models.environment_type import EnvironmentType
-from harbor.models.trial.config import ServiceVolumeConfig
-from harbor.models.trial.paths import EnvironmentPaths
 from strands import tool
 
 from strands_env.core import Environment, ModelFactory
@@ -96,13 +94,6 @@ class HarborEnv(Environment[HarborTask]):
                     session_id=session_id,
                     trial_paths=task.trial_paths,
                     task_env_config=task.task_env_config,
-                    mounts=[
-                        ServiceVolumeConfig(
-                            type="bind",
-                            source=task.trial_paths.verifier_dir.resolve().absolute().as_posix(),
-                            target=str(EnvironmentPaths.verifier_dir),
-                        )
-                    ],
                 )
             case "e2b":
                 # we use prebaked e2b for self-hosting on e.g., AWS


### PR DESCRIPTION
## Summary

- Remove `ServiceVolumeConfig` import and `mounts=` kwarg from `EnvironmentFactory.create_environment` — both were removed in harbor 0.15.
- Bump harbor floor to `>=0.15.0` in pyproject.toml.

The verifier-dir bind mount we were passing manually is now handled by harbor's base docker-compose template (`${HOST_VERIFIER_LOGS_PATH}:${ENV_VERIFIER_LOGS_PATH}`).

## Test plan

- [x] 250 unit tests pass (harbor env tests included)
- [x] ruff clean