### PR TITLE
fix(core): reject max_model_retries < 1 to prevent unbound judgment

### DIFF
--- a/src/strands_env/core/llm_judge_reward.py
+++ b/src/strands_env/core/llm_judge_reward.py
@@ -76,6 +76,8 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
         default_reward: float = 0.0,
         max_model_retries: int = 1,
     ) -> None:
+        if max_model_retries < 1:
+            raise ValueError(f"max_model_retries must be >= 1, got {max_model_retries}")
         self.judge_models = itertools.cycle(judge_model if isinstance(judge_model, list) else [judge_model])
         self.system_prompt = system_prompt
         self.default_reward = default_reward

--- a/tests/unit/core/test_llm_judge_reward.py
+++ b/tests/unit/core/test_llm_judge_reward.py
@@ -16,6 +16,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from pydantic import BaseModel
 from strands.types.exceptions import ModelThrottledException
 
@@ -248,3 +249,8 @@ class TestHappyPath:
 
         assert result.reward == 0.0
         assert result.info["error_type"] == "judge_error"
+
+    def test_non_positive_max_model_retries_rejected(self):
+        """max_model_retries < 1 would skip the judge loop entirely, leaving judgment unbound."""
+        with pytest.raises(ValueError, match="max_model_retries"):
+            _TextJudge(judge_model=MagicMock(), max_model_retries=0)


### PR DESCRIPTION
## Summary

Follow-up to #197. When `max_model_retries` is 0 (or negative), the judge invocation loop `for attempt in range(self.max_model_retries)` never executes, so `judgment` is never bound and the subsequent `judgment.model_dump(...)` raises `UnboundLocalError` instead of returning a proper error `RewardResult`.

Guard at construction time: `__init__` now raises `ValueError` for `max_model_retries < 1`.

## Testing

- New test `test_non_positive_max_model_retries_rejected`
- `pytest tests/unit/core/test_llm_judge_reward.py`: 10 passed
- `mypy src/strands_env`: clean