### PR TITLE
fix(aws): assume roles with the profile's credentials when profile_name is set

### DIFF
--- a/src/strands_env/utils/aws.py
+++ b/src/strands_env/utils/aws.py
@@ -70,26 +70,38 @@ def get_session(
           so they must not be shared across concurrent calls. Use `get_client` instead
           when you need a cached, thread-safe client.
         - If `role_arn` is provided, assumes the role using STS with auto-refreshing
-          credentials via botocore's `RefreshableCredentials`.
+          credentials via botocore's `RefreshableCredentials`. When `profile_name` is
+          also provided, the role is assumed **from that profile's credentials** (a
+          two-hop chain) rather than from the ambient ones — needed when the role's
+          trust policy only admits identities from the profile's account.
     """
     region_name = resolve_region_name(region_name=region_name, profile_name=profile_name)
     if role_arn:
         return create_assumed_role_session(
-            role_arn=role_arn, role_session_name=role_session_name, region_name=region_name
+            role_arn=role_arn,
+            role_session_name=role_session_name,
+            region_name=region_name,
+            profile_name=profile_name,
         )
     session = boto3.Session(region_name=region_name, profile_name=profile_name)
     logger.info("Created boto3 session: region_name=%s, profile_name=%s", session.region_name, session.profile_name)
     return session
 
 
-def create_assumed_role_session(role_arn: str, role_session_name: str, region_name: str) -> boto3.Session:
-    """Create a boto3 session with assumed role credentials."""
+def create_assumed_role_session(
+    role_arn: str, role_session_name: str, region_name: str, profile_name: str | None = None
+) -> boto3.Session:
+    """Create a boto3 session with assumed role credentials.
+
+    `profile_name` selects the credentials the STS `AssumeRole` call is made with;
+    `None` uses the ambient credential chain.
+    """
     from botocore.credentials import RefreshableCredentials
     from botocore.session import get_session as get_botocore_session
 
     def refresh() -> dict:
-        logger.info("Refreshing STS credentials for assumed role: %s", role_arn)
-        sts = boto3.client("sts", region_name=region_name)
+        logger.info("Refreshing STS credentials for assumed role: %s (profile=%s)", role_arn, profile_name)
+        sts = boto3.Session(region_name=region_name, profile_name=profile_name).client("sts", region_name=region_name)
         creds = sts.assume_role(RoleArn=role_arn, RoleSessionName=role_session_name)["Credentials"]
         return {
             "access_key": creds["AccessKeyId"],
@@ -142,7 +154,10 @@ def get_client(
     region_name = resolve_region_name(region_name=region_name, profile_name=profile_name)
     if role_arn:
         session = create_assumed_role_session(
-            role_arn=role_arn, role_session_name=role_session_name, region_name=region_name
+            role_arn=role_arn,
+            role_session_name=role_session_name,
+            region_name=region_name,
+            profile_name=profile_name,
         )
     else:
         session = boto3.Session(region_name=region_name, profile_name=profile_name)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -95,9 +95,9 @@ class TestGetSession:
 
 
 class TestGetSessionWithRoleAssumption:
-    @patch("strands_env.utils.aws.boto3.client")
+    @patch("strands_env.utils.aws.boto3.Session")
     @patch("botocore.session.get_session")
-    def test_assumes_role(self, mock_get_session, mock_boto3_client):
+    def test_assumes_role(self, mock_get_session, mock_session_cls):
         from datetime import datetime
 
         mock_sts = MagicMock()
@@ -109,7 +109,7 @@ class TestGetSessionWithRoleAssumption:
                 "Expiration": datetime.now(UTC),
             }
         }
-        mock_boto3_client.return_value = mock_sts
+        mock_session_cls.return_value.client.return_value = mock_sts
 
         mock_botocore_session = MagicMock()
         mock_get_session.return_value = mock_botocore_session
@@ -117,14 +117,43 @@ class TestGetSessionWithRoleAssumption:
         role_arn = "arn:aws:iam::123456789:role/TestRole"
         session = get_session(region_name="us-east-1", role_arn=role_arn)
 
-        mock_boto3_client.assert_called_with("sts", region_name="us-east-1")
+        # The STS client is built from a Session carrying the (absent) profile.
+        mock_session_cls.assert_any_call(region_name="us-east-1", profile_name=None)
+        mock_session_cls.return_value.client.assert_called_with("sts", region_name="us-east-1")
         mock_sts.assume_role.assert_called_with(RoleArn=role_arn, RoleSessionName="strands-env")
         assert session is not None
 
-    @patch("strands_env.utils.aws.boto3.client")
-    def test_has_refreshable_credentials(self, mock_boto3_client):
+    @patch("strands_env.utils.aws.boto3.Session")
+    @patch("botocore.session.get_session")
+    def test_assumes_role_from_profile(self, mock_get_session, mock_session_cls):
+        from datetime import datetime
+
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "AKIA_TEST",
+                "SecretAccessKey": "secret_test",
+                "SessionToken": "token_test",
+                "Expiration": datetime.now(UTC),
+            }
+        }
+        mock_session_cls.return_value.client.return_value = mock_sts
+        mock_session_cls.return_value.region_name = "us-east-1"
+        mock_get_session.return_value = MagicMock()
+
+        role_arn = "arn:aws:iam::123456789:role/TestRole"
+        session = get_session(region_name="us-east-1", role_arn=role_arn, profile_name="test-profile")
+
+        # The AssumeRole call must run with the profile's credentials (two-hop chain).
+        mock_session_cls.assert_any_call(region_name="us-east-1", profile_name="test-profile")
+        mock_sts.assume_role.assert_called_with(RoleArn=role_arn, RoleSessionName="strands-env")
+        assert session is not None
+
+    @patch("strands_env.utils.aws.boto3.Session")
+    def test_has_refreshable_credentials(self, mock_session_cls):
         from datetime import datetime, timedelta
 
+        from boto3.session import Session as RealSession
         from botocore.credentials import RefreshableCredentials
 
         mock_sts = MagicMock()
@@ -136,7 +165,18 @@ class TestGetSessionWithRoleAssumption:
                 "Expiration": datetime.now(UTC) + timedelta(hours=1),
             }
         }
-        mock_boto3_client.return_value = mock_sts
+        mock_sts_session = MagicMock()
+        mock_sts_session.client.return_value = mock_sts
+        mock_sts_session.region_name = None
+
+        def session_side_effect(*args, **kwargs):
+            # The final wrapper Session must be real so its credential plumbing works;
+            # every other Session (region resolution, STS) stays mocked.
+            if "botocore_session" in kwargs:
+                return RealSession(*args, **kwargs)
+            return mock_sts_session
+
+        mock_session_cls.side_effect = session_side_effect
 
         role_arn = "arn:aws:iam::123456789:role/TestRole"
         session = get_session(role_arn=role_arn)


### PR DESCRIPTION
## Summary

`create_assumed_role_session` dropped `profile_name`: the STS `AssumeRole` call always
ran with ambient credentials, so `get_session(profile_name=..., role_arn=...)` silently
ignored the profile. Cross-account role chains (profile → role) where the role's trust
policy only admits identities from the profile's account were impossible.

The fix threads `profile_name` into `create_assumed_role_session` so the STS client is
built from the profile session. `None` preserves the ambient-chain behavior. Both
`get_session` and `get_client` now pass `profile_name` through.

## Test plan

- Verified with a cross-account setup: `get_session(profile_name=..., role_arn=...)` where the role's trust policy only admits the profile's account now resolves to the assumed-role identity (previously AccessDenied because the AssumeRole call ran with ambient credentials from a different account)
- `get_session(role_arn=..., profile_name=None)` behavior unchanged (ambient chain)
- `get_session(profile_name=..., role_arn=None)` behavior unchanged (profile session, no assume)
- ruff/mypy clean