### PR TITLE
fix(lint): pin ruff floor to 0.16.0 and reformat markdown code blocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pytest-timeout>=2.0.0",
     # Linting & Build
     "pre-commit",
-    "ruff>=0.6.0",
+    "ruff>=0.16.0",
     "twine>=4.0.0",
     "build>=0.10.0",
     # Type checking

--- a/src/strands_env/environments/agent_world_model/README.md
+++ b/src/strands_env/environments/agent_world_model/README.md
@@ -25,7 +25,7 @@ task = AgentWorldModelTask(
     message="Add two apples to the cart and report the total.",
     scenario="your_scenario",
     task_idx=0,
-    verify_code=verify_code,          # from gen_verifier.pure_code.jsonl
+    verify_code=verify_code,  # from gen_verifier.pure_code.jsonl
     initial_db_path="/path/to/initial.db",
 )
 result = await env.rollout(task)  # reset (clone DB + start server) -> episode -> reward -> cleanup

--- a/src/strands_env/environments/mcp_atlas/README.md
+++ b/src/strands_env/environments/mcp_atlas/README.md
@@ -32,7 +32,7 @@ task = MCPAtlasTask(
     gtfa_claims=claims,
 )
 result = await env.rollout(task)  # reset (fetch + filter tools) -> episode -> reward -> cleanup
-await http_client.aclose()        # once, after ALL rollouts
+await http_client.aclose()  # once, after ALL rollouts
 ```
 
 ## Configuration

--- a/src/strands_env/environments/tau2_bench/README.md
+++ b/src/strands_env/environments/tau2_bench/README.md
@@ -26,9 +26,9 @@ The DB, policy, and task data live in the tau2 repo (not the pip wheel); the eva
 from strands_env.environments.tau2_bench import Tau2BenchEnv, Tau2BenchTask
 
 env = Tau2BenchEnv(
-    agent_model_factory=agent_model_factory,    # the model under test
-    user_model_factory=user_model_factory,      # drives the user-simulator
-    judge_model_factory=judge_model_factory,    # optional; only used for NL-assertion reward
+    agent_model_factory=agent_model_factory,  # the model under test
+    user_model_factory=user_model_factory,  # drives the user-simulator
+    judge_model_factory=judge_model_factory,  # optional; only used for NL-assertion reward
     max_steps=100,
 )
 


### PR DESCRIPTION
## Summary
- PR #201's lint job failed because CI installs the latest `ruff` on every run (`ruff>=0.6.0`, no ceiling), and ruff 0.16.0 changed how `ruff format` normalizes trailing-comment alignment inside fenced Python blocks in Markdown. Three READMEs had hand-aligned comments that ruff 0.14.x (used locally) didn't flag but 0.16.0 does.
- Confirmed this is pre-existing drift, not caused by #201 — the same 3 files fail under ruff 0.16.0 even at the commit prior to #201.
- Bumped the dev dependency floor to `ruff>=0.16.0` so local environments match what CI actually enforces, and reformatted the affected files with 0.16.0.

## Test plan
- [x] `ruff format --check src/ tests/ examples/` passes under ruff 0.16.0
- [x] `ruff check src/ tests/ examples/` passes under ruff 0.16.0