### PR TITLE
feat(harbor): add start_jitter to stagger sandbox creation

### DIFF
--- a/src/strands_env/environments/harbor/README.md
+++ b/src/strands_env/environments/harbor/README.md
@@ -51,6 +51,7 @@ result = await env.rollout(task)  # reset (build + start container) -> episode -
 |---|---|---|
 | `backend` | `"docker"` | `"docker"` or `"e2b"` |
 | `exec_timeout` | `1200` | Seconds per `sandbox.exec` command; also the verifier fallback |
+| `start_jitter` | `0.0` | Sleep `uniform(0, start_jitter)` seconds before starting the sandbox, so a wide sweep doesn't open every sandbox in the same tick |
 | `prebaked_e2b_config` | `{}` | e2b connection + template map (see `PrebakedE2BConfig`) |
 
 Base knobs come from `EnvironmentConfig`.

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -20,6 +20,8 @@ solves it via a single `execute_command` tool and Harbor's `Verifier` grades the
 
 from __future__ import annotations
 
+import asyncio
+import random
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NotRequired, Unpack, override
@@ -54,6 +56,7 @@ class HarborConfig(EnvironmentConfig):
 
     exec_timeout: NotRequired[int]  # sandbox.exec timeout; also the verifier fallback
     backend: NotRequired[Literal["docker", "e2b"]]
+    start_jitter: NotRequired[float]  # max seconds to sleep before starting the sandbox (0 disables)
     prebaked_e2b_config: NotRequired[PrebakedE2BConfig]
 
 
@@ -71,6 +74,7 @@ class HarborEnv(Environment[HarborTask]):
         super().__init__(model_factory=model_factory, **config)  # type: ignore[misc]
         self.exec_timeout: int = int(self.config.get("exec_timeout", 1200))
         self.backend: Literal["docker", "e2b"] = self.config.get("backend", "docker")
+        self.start_jitter: float = float(self.config.get("start_jitter", 0.0))
         self.prebaked_e2b_config: PrebakedE2BConfig = self.config.get("prebaked_e2b_config", {})
         self.sandbox: HarborEnvironment | None = None
         # Harbor's reward is tied to the sandbox, so we don't need to pass it in.
@@ -109,6 +113,10 @@ class HarborEnv(Environment[HarborTask]):
                 )
                 # Prebaked templates are static; force_build is a no-op here.
                 force_build = False
+
+        # Add a random jitter to reduce sandbox startup contention.
+        if self.start_jitter > 0:
+            await asyncio.sleep(random.uniform(0, self.start_jitter))
 
         await self.sandbox.start(force_build=force_build)
 

--- a/tests/unit/environments/harbor/test_env.py
+++ b/tests/unit/environments/harbor/test_env.py
@@ -24,13 +24,15 @@ loading with a `NameError`.
 from __future__ import annotations
 
 import typing
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
 
 pytest.importorskip("harbor", reason="harbor>=0.13.2 required for HarborConfig")
 
-from strands_env.environments.harbor.env import HarborConfig  # noqa: E402
+from strands_env.environments.harbor import env as harbor_env  # noqa: E402
+from strands_env.environments.harbor.env import HarborConfig, HarborEnv  # noqa: E402
 from strands_env.environments.harbor.task import HarborTask  # noqa: E402
 
 
@@ -39,6 +41,7 @@ def test_harbor_config_type_hints_resolve():
     hints = typing.get_type_hints(HarborConfig)
     assert "prebaked_e2b_config" in hints
     assert "backend" in hints
+    assert "start_jitter" in hints
     assert "system_prompt" in hints  # inherited from EnvironmentConfig
 
 
@@ -59,3 +62,52 @@ def test_harbor_task_round_trips():
     again = HarborTask.model_validate_json(task.model_dump_json())
     assert again.task_id == "t"
     assert again.trial_dir == "/o"
+
+
+async def _reset_with(jitter_config: dict, tmp_path) -> MagicMock:
+    """Run `reset()` on a docker-backed env and return the patched `asyncio.sleep` mock.
+
+    The docker backend is used because its sandbox comes from a factory we can patch
+    wholesale, so `reset()` runs end to end without Docker installed.
+    """
+    env = HarborEnv(model_factory=MagicMock(), backend="docker", **jitter_config)
+    task = HarborTask(message="m", task_id="t", task_dir=str(tmp_path), trial_dir=str(tmp_path / "trial"))
+    sandbox = MagicMock()
+    sandbox.start = AsyncMock()
+
+    with (
+        patch.object(harbor_env.EnvironmentFactory, "create_environment", return_value=sandbox),
+        patch.object(harbor_env.asyncio, "sleep", new=AsyncMock()) as sleep,
+    ):
+        await env.reset(task)
+
+    sandbox.start.assert_awaited_once()
+    return sleep
+
+
+class TestStartJitter:
+    """`start_jitter` staggers sandbox creation across concurrent episodes."""
+
+    async def test_defaults_to_no_sleep(self, tmp_path):
+        """Unset `start_jitter` must not add latency to a serial or low-concurrency run."""
+        env = HarborEnv(model_factory=MagicMock(), backend="docker")
+        assert env.start_jitter == 0.0
+        sleep = await _reset_with({}, tmp_path)
+        sleep.assert_not_awaited()
+
+    async def test_sleeps_within_the_window(self, tmp_path):
+        """A positive `start_jitter` sleeps somewhere in [0, jitter) before starting."""
+        sleep = await _reset_with({"start_jitter": 30.0}, tmp_path)
+        sleep.assert_awaited_once()
+        assert 0 <= sleep.await_args.args[0] < 30.0
+
+    async def test_zero_is_treated_as_disabled(self, tmp_path):
+        """An explicit 0 disables the sleep rather than awaiting `sleep(0)`."""
+        sleep = await _reset_with({"start_jitter": 0}, tmp_path)
+        sleep.assert_not_awaited()
+
+    def test_int_config_is_coerced_to_float(self):
+        """`--env-config` JSON yields ints; they must not break the comparison or sleep."""
+        env = HarborEnv(model_factory=MagicMock(), backend="docker", start_jitter=15)  # type: ignore[typeddict-item]
+        assert env.start_jitter == 15.0
+        assert isinstance(env.start_jitter, float)


### PR DESCRIPTION
High concurrency sends a wide sweep sends N `POST /sandboxes` together. A self-hosted e2b gateway sheds part of that spike by dropping connections, and the affected episodes abort seconds after launch with an HTTP/2 transport error and an empty trajectory — no messages, no metrics, dead before the first model call.

Retries don't cover it: harbor's base `E2BEnvironment` already retries `_create_sandbox`, but the wait has no jitter and a retry re-sends into the same spike. The fix is a pre-create stagger.

`start_jitter` sleeps `uniform(0, start_jitter)` in `reset()` before `sandbox.start()`, after the local setup so only the network call is delayed. It sits on `HarborConfig` rather than `PrebakedE2BConfig` so it stays backend-agnostic and reachable as one top-level `--env-config` key. Default 0.0 keeps serial and low-concurrency runs unchanged.

Measured on a self-hosted e2b cluster: at 89-wide the creates went from a 5-7s window peaking at 31-57/s to a 10s window peaking at 23/s, and at 150-wide from a 30s window peaking at 40-69/s to 21s peaking at 20/s, with no aborts in the jittered runs.